### PR TITLE
feat: add modular schema validation for config loading

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,6 +27,8 @@ exclude:
   - Gemfile.lock
   - node_modules
   - vendor
+  - AOP
+  - snyk-gitlab-setup.md
 
 # Collections (optional, for future expansion)
 # collections:
@@ -56,5 +58,11 @@ navigation:
     url: "{{ site.baseurl }}/security"
   - title: CLI
     url: "{{ site.baseurl }}/cli"
+  - title: Schema Validation
+    url: "{{ site.baseurl }}/schema-validation"
+  - title: Dependency Injection
+    url: "{{ site.baseurl }}/dependency-injection"
+  - title: Dynamic Instantiation
+    url: "{{ site.baseurl }}/instantiation"
   - title: FAQ
     url: "{{ site.baseurl }}/faq"

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,180 +1,93 @@
 # Core API
 
-The core API provides the primary interfaces for loading and accessing configuration.
+The core API loads configuration and exposes it as a read-oriented mapping.
 
-## load_config()
+## `load_config()`
 
-The main entry point for loading configuration. This is a convenience function that creates a `ConfigLoader` instance and returns a `Config` object.
+```python
+from pathlib import Path
+from sprigconfig import load_config
+
+cfg = load_config(profile="prod", config_dir=Path("config"))
+```
+
+`profile` is required. `config_dir` may be omitted only when
+`APP_CONFIG_DIR` is set. The optional `schema` argument accepts a dataclass
+type; see [Schema Validation](../schema-validation.md).
 
 ::: sprigconfig.load_config
 
-**Example:**
+## `ConfigLoader`
+
+Use the loader directly to select a file format:
 
 ```python
-from sprigconfig import load_config
+from pathlib import Path
+from sprigconfig import ConfigLoader
 
-# Basic usage
-cfg = load_config()
-
-# With explicit profile
-cfg = load_config(profile="prod")
-
-# With custom config directory
-cfg = load_config(config_dir="/etc/myapp/config")
+cfg = ConfigLoader(
+    config_dir=Path("config"),
+    profile="prod",
+    config_format="json",
+).load()
 ```
 
----
-
-## Config
-
-A dict-like wrapper that provides convenient access to configuration values with support for dotted-key notation.
-
-::: sprigconfig.Config
-    options:
-      show_root_heading: true
-      show_source: true
-      members:
-        - __init__
-        - get
-        - __getitem__
-        - __setitem__
-        - __contains__
-        - keys
-        - values
-        - items
-        - to_dict
-
-**Example:**
-
-```python
-from sprigconfig import load_config
-
-cfg = load_config()
-
-# Dict-like access
-db_host = cfg["database"]["host"]
-
-# Dotted-key access
-db_host = cfg.get("database.host")
-
-# Default values
-timeout = cfg.get("database.timeout", 30)
-
-# Check if key exists
-if "features.analytics" in cfg:
-    print("Analytics configured")
-
-# Iterate over keys
-for key in cfg.keys():
-    print(key)
-
-# Convert to plain dict
-plain_dict = cfg.to_dict()
-```
-
----
-
-## ConfigLoader
-
-The primary configuration loading engine. Handles file discovery, parsing, merging, profile overlays, and imports.
+| Parameter | Required | Meaning |
+| --- | --- | --- |
+| `config_dir` | Yes, unless passed as `None` with `APP_CONFIG_DIR` set | Configuration directory |
+| `profile` | Yes | Runtime overlay name |
+| `config_format` | No | `yaml`/`yml`, `json`, or `toml`; defaults to `SPRIGCONFIG_FORMAT`, then YAML |
+| `schema` | No | Dataclass type for opt-in validation |
 
 ::: sprigconfig.ConfigLoader
     options:
-      show_root_heading: true
-      show_source: true
       members:
         - __init__
         - load
-        - _resolve_profile
-        - _resolve_config_dir
 
-**Example:**
+## `Config`
 
-```python
-from sprigconfig import ConfigLoader
-from pathlib import Path
-
-# Create loader with explicit settings
-loader = ConfigLoader(
-    config_dir=Path("./config"),
-    profile="prod"
-)
-
-# Load configuration
-cfg = loader.load()
-
-# Access values
-print(cfg.get("app.name"))
-```
-
-**Advanced Usage:**
+`Config` implements `collections.abc.Mapping` and supports literal and dotted
+key lookup:
 
 ```python
-# Programmatic profile resolution
-import os
+port = cfg["database.port"]
+port = cfg["database"]["port"]
+timeout = cfg.get("database.timeout", 30)
 
-profile = os.environ.get("DEPLOY_ENV", "dev")
-loader = ConfigLoader(profile=profile)
-cfg = loader.load()
+if "database.port" in cfg:
+    print(port)
 
-# Custom config directory from environment
-config_dir = os.environ.get("APP_CONFIG_DIR", "./config")
-loader = ConfigLoader(config_dir=config_dir)
-cfg = loader.load()
+plain = cfg.to_dict()  # LazySecret values are redacted
+yaml_text = cfg.dump()
 ```
 
----
+Nested mappings are returned as `Config` objects. Lists remain lists, with
+nested mappings wrapped when the configuration is constructed.
 
-## Key Concepts
+`Config.dump()` produces a YAML snapshot of the fully assembled configuration,
+which is useful for debugging recursive imports, profile overlays, and
+provenance. Secrets are redacted by default, and `sprigconfig_first=True` puts
+merge metadata at the top. The CLI supports YAML or JSON output when a JSON
+snapshot is needed.
 
-### Configuration Loading Flow
+::: sprigconfig.Config
+    options:
+      members:
+        - get
+        - __getitem__
+        - __contains__
+        - to_dict
+        - dump
 
-1. **Profile Resolution**: Determine active profile (explicit, `APP_PROFILE`, pytest context, or 'dev')
-2. **Directory Resolution**: Locate config directory (explicit, `APP_CONFIG_DIR`, or './config')
-3. **File Discovery**: Find `application.<ext>` and `application-<profile>.<ext>`
-4. **Parsing**: Parse configuration files (YAML, JSON, or TOML)
-5. **Merging**: Deep merge base + imports + profile + profile imports
-6. **Processing**: Expand environment variables, create LazySecret objects
-7. **Metadata**: Inject `sprigconfig._meta` with provenance information
+## Loading sequence
 
-### Profile Behavior
+1. Resolve YAML/JSON/TOML root files for the requested format.
+2. Expand environment placeholders before parsing each file.
+3. Resolve recursive imports.
+4. Merge the base layer with the optional profile overlay.
+5. Run schema validation when `schema=` was supplied.
+6. Inject the runtime profile and provenance metadata.
+7. Wrap `ENC(...)` strings as `LazySecret` objects.
 
-Profiles are **runtime-driven** and never read from configuration files:
-
-- Explicit: `load_config(profile="prod")`
-- Environment: `APP_PROFILE=prod`
-- Pytest: Automatically uses "test"
-- Default: "dev"
-
-### File Formats
-
-SprigConfig supports three configuration formats:
-
-- **YAML** (`.yml`, `.yaml`) - Default, most common
-- **JSON** (`.json`) - Structured data
-- **TOML** (`.toml`) - Configuration-focused
-
-**Important:** Use exactly one format per project. Mixed-format imports are not supported.
-
-### Merge Semantics
-
-Configuration is merged in this order (later overrides earlier):
-
-1. `application.<ext>` (base)
-2. Base imports
-3. `application-<profile>.<ext>` (profile overlay)
-4. Profile imports
-
-This ensures profile-specific settings always have final say.
-
----
-
-## Thread Safety
-
-All core API components are thread-safe:
-
-- `load_config()` can be called from multiple threads
-- `Config` objects are safe for concurrent reads
-- Use `ConfigSingleton` for shared configuration across threads
-
-See [Utilities API](utilities.md#configsingleton) for thread-safe caching patterns.
+All files participating in one load use the selected format.

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,412 +1,58 @@
-# Exceptions API
+# Exceptions
 
-Error handling and exception classes for SprigConfig.
+## `ConfigLoadError`
 
-## ConfigLoadError
-
-Base exception for all configuration loading errors.
-
-::: sprigconfig.exceptions.ConfigLoadError
-    options:
-      show_root_heading: true
-      show_source: true
-
-**Example:**
+`ConfigLoadError` is the common public error for loading, parsing, imports,
+secret handling, configuration injection, and dynamic instantiation.
 
 ```python
-from sprigconfig import load_config, ConfigLoadError
+from sprigconfig import ConfigLoadError, load_config
 
 try:
-    cfg = load_config(profile="prod")
-except ConfigLoadError as e:
-    print(f"Failed to load configuration: {e}")
-    # Handle error (use defaults, exit, etc.)
+    cfg = load_config(profile="prod", config_dir="config")
+except ConfigLoadError as error:
+    raise SystemExit(f"Configuration failed: {error}") from error
 ```
 
----
+Typical causes include:
 
-## Exception Hierarchy
+- unsupported configuration formats;
+- missing `APP_CONFIG_DIR` when no directory is supplied;
+- invalid YAML, JSON, or TOML;
+- missing, invalid, escaping, or circular imports;
+- invalid or unavailable Fernet keys when a secret is decrypted;
+- invalid injection or `_target_` configuration.
 
-SprigConfig uses a simple exception hierarchy:
+Missing root and profile files currently produce empty layers rather than an
+exception. Check required files in application startup when your deployment
+policy demands them.
 
+## `ConfigValidationError`
+
+`ConfigValidationError` extends `ConfigLoadError`, so existing broad error
+handlers continue to work:
+
+```python
+from sprigconfig import ConfigLoadError, ConfigValidationError
+
+assert issubclass(ConfigValidationError, ConfigLoadError)
 ```
-Exception
-└── ConfigLoadError (base for all config errors)
-```
 
-All configuration-related errors inherit from `ConfigLoadError`, making it easy to catch any config-related issue:
+It is raised only when `schema=` is supplied and the merged configuration does
+not match the dataclass schema. See [Schema Validation](../schema-validation.md).
+
+## Handling errors
+
+Catch the narrow exception when validation needs different reporting:
 
 ```python
 try:
-    cfg = load_config()
-except ConfigLoadError:
-    # Catches all config-related errors
-    handle_config_error()
+    cfg = load_config(profile="prod", config_dir="config", schema=AppSchema)
+except ConfigValidationError as error:
+    print(f"Invalid configuration shape: {error}")
+except ConfigLoadError as error:
+    print(f"Could not load configuration: {error}")
 ```
 
----
-
-## Common Error Scenarios
-
-### 1. Missing Configuration File
-
-**Scenario:** Required configuration file not found
-
-```python
-# config/application.yml does not exist
-from sprigconfig import load_config, ConfigLoadError
-
-try:
-    cfg = load_config()
-except ConfigLoadError as e:
-    print(f"Error: {e}")
-    # "Configuration file not found: config/application.yml"
-```
-
-**Solutions:**
-- Create the missing file
-- Check `config_dir` parameter
-- Set `APP_CONFIG_DIR` environment variable
-
-### 2. Production Profile Missing
-
-**Scenario:** Production mode requires `application-prod.yml` to exist
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-
-try:
-    cfg = load_config(profile="prod")
-except ConfigLoadError as e:
-    print(f"Error: {e}")
-    # "Production profile requires application-prod.yml"
-```
-
-**Solution:**
-- Create `config/application-prod.yml`
-- This is a safety feature to prevent accidental production deployments with dev config
-
-### 3. Invalid YAML/JSON/TOML Syntax
-
-**Scenario:** Configuration file has syntax errors
-
-```yaml
-# config/application.yml (invalid)
-database:
-  host: localhost
-  port: [invalid syntax here
-```
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-
-try:
-    cfg = load_config()
-except ConfigLoadError as e:
-    print(f"Parse error: {e}")
-```
-
-**Solutions:**
-- Validate YAML/JSON/TOML syntax
-- Use a linter or validator
-- Check for common issues (indentation, quotes, commas)
-
-### 4. Circular Import Detected
-
-**Scenario:** Configuration files import each other in a loop
-
-```yaml
-# config/application.yml
-imports:
-  - database.yml
-
-# config/database.yml
-imports:
-  - application.yml  # Circular!
-```
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-
-try:
-    cfg = load_config()
-except ConfigLoadError as e:
-    print(f"Error: {e}")
-    # "Circular import detected: application.yml -> database.yml -> application.yml"
-```
-
-**Solution:**
-- Remove circular imports
-- Restructure your configuration files
-- Use a hierarchical import structure
-
-### 5. Missing Encryption Key
-
-**Scenario:** Configuration has encrypted secrets but `APP_SECRET_KEY` not set
-
-```yaml
-# config/application.yml
-database:
-  password: ENC(gAAAAAB...)  # Encrypted secret
-```
-
-```python
-from sprigconfig import load_config
-
-cfg = load_config()
-
-# Later, when trying to decrypt
-try:
-    password = cfg["database"]["password"].get()
-except Exception as e:
-    print(f"Decryption error: {e}")
-    # "No encryption key available"
-```
-
-**Solutions:**
-- Set `APP_SECRET_KEY` environment variable
-- Use `LazySecret.set_global_key_provider()`
-- Pass key explicitly: `secret.get(key="your-key")`
-
-### 6. Invalid Configuration Directory
-
-**Scenario:** Specified config directory doesn't exist
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-
-try:
-    cfg = load_config(config_dir="/nonexistent/path")
-except ConfigLoadError as e:
-    print(f"Error: {e}")
-    # "Configuration directory not found: /nonexistent/path"
-```
-
-**Solution:**
-- Verify the path exists
-- Check file permissions
-- Use absolute paths to avoid ambiguity
-
----
-
-## Error Handling Patterns
-
-### Pattern 1: Graceful Degradation
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-
-def get_config():
-    """Load config with fallback to defaults."""
-    try:
-        return load_config()
-    except ConfigLoadError as e:
-        print(f"Warning: Using default config due to: {e}")
-        return {
-            "database": {"host": "localhost", "port": 5432},
-            "app": {"debug": False}
-        }
-
-cfg = get_config()
-```
-
-### Pattern 2: Fail Fast
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-import sys
-
-try:
-    cfg = load_config(profile="prod")
-except ConfigLoadError as e:
-    print(f"FATAL: Cannot load configuration: {e}", file=sys.stderr)
-    sys.exit(1)
-
-# Continue with valid config
-```
-
-### Pattern 3: Detailed Error Logging
-
-```python
-import logging
-from sprigconfig import load_config, ConfigLoadError
-
-logger = logging.getLogger(__name__)
-
-try:
-    cfg = load_config()
-except ConfigLoadError as e:
-    logger.error(
-        "Configuration load failed",
-        exc_info=True,
-        extra={
-            "error": str(e),
-            "profile": "dev",
-            "config_dir": "./config"
-        }
-    )
-    raise
-```
-
-### Pattern 4: Retry with Fallback
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-import os
-
-def load_with_fallback():
-    """Try loading from primary location, then fallback."""
-    try:
-        return load_config(config_dir="/etc/myapp/config")
-    except ConfigLoadError:
-        # Try fallback location
-        try:
-            return load_config(config_dir="./config")
-        except ConfigLoadError as e:
-            raise ConfigLoadError(
-                f"Failed to load config from primary and fallback locations: {e}"
-            )
-
-cfg = load_with_fallback()
-```
-
----
-
-## Validation and Error Prevention
-
-### Pre-flight Checks
-
-```python
-from pathlib import Path
-from sprigconfig import load_config, ConfigLoadError
-
-def validate_config_setup(profile="dev"):
-    """Validate configuration before loading."""
-    config_dir = Path("./config")
-
-    # Check directory exists
-    if not config_dir.exists():
-        raise ConfigLoadError(f"Config directory not found: {config_dir}")
-
-    # Check base file exists
-    base_file = config_dir / "application.yml"
-    if not base_file.exists():
-        raise ConfigLoadError(f"Base config not found: {base_file}")
-
-    # Check profile file exists (for prod)
-    if profile == "prod":
-        profile_file = config_dir / f"application-{profile}.yml"
-        if not profile_file.exists():
-            raise ConfigLoadError(f"Profile config not found: {profile_file}")
-
-    return True
-
-# Validate before loading
-validate_config_setup(profile="prod")
-cfg = load_config(profile="prod")
-```
-
-### Custom Validation
-
-```python
-from sprigconfig import load_config, ConfigLoadError
-
-def load_and_validate():
-    """Load config and validate required keys."""
-    cfg = load_config()
-
-    # Validate required keys
-    required_keys = [
-        "database.host",
-        "database.port",
-        "app.name"
-    ]
-
-    for key in required_keys:
-        if key not in cfg:
-            raise ConfigLoadError(f"Required configuration key missing: {key}")
-
-    # Validate value types
-    if not isinstance(cfg.get("database.port"), int):
-        raise ConfigLoadError("database.port must be an integer")
-
-    return cfg
-
-cfg = load_and_validate()
-```
-
----
-
-## Debugging Configuration Errors
-
-### Enable Debug Logging
-
-```python
-import logging
-from sprigconfig import load_config
-
-# Enable debug logging
-logging.basicConfig(level=logging.DEBUG)
-
-# Load config (will show detailed debug info)
-cfg = load_config()
-```
-
-### Use CLI for Inspection
-
-```bash
-# Dump configuration to see what's loaded
-sprigconfig dump --profile dev
-
-# Validate configuration syntax
-sprigconfig dump --profile prod --format yaml
-```
-
-### Check Configuration Files
-
-```python
-import yaml
-from pathlib import Path
-
-# Manually validate YAML syntax
-config_file = Path("config/application.yml")
-try:
-    with open(config_file) as f:
-        data = yaml.safe_load(f)
-    print(f"Valid YAML: {config_file}")
-except yaml.YAMLError as e:
-    print(f"Invalid YAML: {e}")
-```
-
----
-
-## Error Messages
-
-SprigConfig provides clear, actionable error messages:
-
-| Error | Message | Solution |
-|-------|---------|----------|
-| Missing file | `Configuration file not found: config/application.yml` | Create the file or check path |
-| Parse error | `Failed to parse config/application.yml: invalid syntax` | Fix YAML/JSON/TOML syntax |
-| Circular import | `Circular import detected: a.yml -> b.yml -> a.yml` | Remove circular dependency |
-| Production guard | `Production profile requires application-prod.yml` | Create prod config file |
-| Missing key | `Required key not found: database.host` | Add missing configuration |
-
----
-
-## Best Practices
-
-1. **Always catch ConfigLoadError** - Don't let config errors crash silently
-2. **Log detailed errors** - Include context (profile, paths) in error logs
-3. **Validate early** - Check config at startup, not during requests
-4. **Provide defaults** - Have sensible fallbacks for non-critical config
-5. **Test error paths** - Write tests for config loading failures
-6. **Document required config** - Make it clear what config is needed
-
----
-
-## Related Documentation
-
-- [Core API](core.md) - Main configuration loading
-- [Configuration Guide](../configuration.md) - General usage patterns
-- [FAQ](../faq.md) - Common questions and troubleshooting
+Do not log decrypted secret values or dump configuration with `safe=False` in
+an exception handler.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -17,7 +17,7 @@ SprigConfig exposes a minimal, stable API surface designed for ease of use and b
 
 ```python
 from sprigconfig import load_config, Config, ConfigLoader
-from sprigconfig import ConfigLoadError
+from sprigconfig import ConfigLoadError, ConfigValidationError
 from sprigconfig.lazy_secret import LazySecret
 ```
 
@@ -35,13 +35,13 @@ from sprigconfig.lazy_secret import LazySecret
 from sprigconfig import load_config
 
 # Load with automatic profile detection
-cfg = load_config()
+cfg = load_config(profile="dev", config_dir="config")
 
 # Load with explicit profile
-cfg = load_config(profile="prod")
+cfg = load_config(profile="prod", config_dir="config")
 
 # Load from custom directory
-cfg = load_config(config_dir="/path/to/config")
+cfg = load_config(profile="prod", config_dir="/path/to/config")
 ```
 
 ### Using ConfigLoader Directly
@@ -105,7 +105,7 @@ SprigConfig is fully type-annotated. Use type checkers like mypy:
 ```python
 from sprigconfig import Config, load_config
 
-cfg: Config = load_config(profile="dev")
+cfg: Config = load_config(profile="dev", config_dir="config")
 ```
 
 ## Next Steps
@@ -113,4 +113,4 @@ cfg: Config = load_config(profile="dev")
 - Browse the [Core API](core.md) for main functionality
 - Check [Secrets](secrets.md) for encrypted configuration
 - See [Configuration Guide](../configuration.md) for usage patterns
-- Review [Examples](https://gitlab.com/dgw_software/sprig-config/-/tree/main/sprig-config-module/examples) for real-world code
+- Review [Examples](https://github.com/derikgw/sprig-config/tree/main/sprig-config-module/examples) for real-world code

--- a/docs/api/secrets.md
+++ b/docs/api/secrets.md
@@ -27,7 +27,7 @@ A secure wrapper for encrypted configuration values that provides lazy decryptio
 ```python
 from sprigconfig import load_config
 
-cfg = load_config()
+cfg = load_config(profile="dev", config_dir="config")
 
 # Secret is still encrypted at this point
 db_password = cfg["database"]["password"]  # LazySecret object
@@ -69,7 +69,7 @@ def get_key_from_vault():
 LazySecret.set_global_key_provider(get_key_from_vault)
 
 # Now all LazySecret.get() calls will use this key
-cfg = load_config()
+cfg = load_config(profile="dev", config_dir="config")
 password = cfg["database"]["password"].get()  # Uses global provider
 ```
 
@@ -121,7 +121,7 @@ Secrets are not decrypted until explicitly requested:
 
 ```python
 # Load config - secrets remain encrypted
-cfg = load_config()
+cfg = load_config(profile="dev", config_dir="config")
 
 # Access secret object - still encrypted
 secret = cfg["api"]["key"]  # LazySecret object
@@ -279,7 +279,7 @@ api:
 from sprigconfig import load_config
 from sprigconfig.lazy_secret import LazySecret
 
-cfg = load_config()
+cfg = load_config(profile="dev", config_dir="config")
 
 try:
     password = cfg["database"]["password"].get()
@@ -297,7 +297,7 @@ Common errors:
 
 ## Examples
 
-See the [Secrets Example](https://gitlab.com/dgw_software/sprig-config/-/tree/main/sprig-config-module/examples/secrets) for complete working code demonstrating:
+See the [Secrets Example](https://github.com/derikgw/sprig-config/tree/main/sprig-config-module/examples/secrets) for complete working code demonstrating:
 
 - Key generation
 - Secret encryption
@@ -310,5 +310,5 @@ See the [Secrets Example](https://gitlab.com/dgw_software/sprig-config/-/tree/ma
 ## Related Documentation
 
 - [Security Guide](../security.md) - Overall security best practices
-- [Best Practices Guide](../../sprig-config-module/docs/SprigConfig_ENC_BestPractices.md) - Detailed encryption patterns
+- [Security Guide](../security.md) - Encryption and operational guidance
 - [Configuration Guide](../configuration.md) - General configuration usage

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -1,334 +1,68 @@
 # Utilities API
 
-Advanced utilities for configuration management and merging.
+## `deep_merge()`
 
-## deep_merge()
-
-A utility function for deeply merging nested dictionaries with override semantics.
-
-::: sprigconfig.deepmerge.deep_merge
-    options:
-      show_root_heading: true
-      show_source: true
-
-**Example:**
+`deep_merge(base, override)` recursively merges `override` into `base` and
+returns the mutated `base` mapping.
 
 ```python
 from sprigconfig import deep_merge
 
-base = {
-    "database": {
-        "host": "localhost",
-        "port": 5432,
-        "pool_size": 10
-    },
-    "features": {
-        "analytics": False
-    }
-}
+base = {"server": {"host": "localhost", "port": 8080}}
+override = {"server": {"port": 9090}}
 
-override = {
-    "database": {
-        "port": 3306,  # Override
-        "ssl": True    # Add new key
-    },
-    "features": {
-        "analytics": True  # Override
-    }
-}
-
-result = deep_merge(base, override)
-# {
-#     "database": {
-#         "host": "localhost",      # From base
-#         "port": 3306,             # Overridden
-#         "pool_size": 10,          # From base
-#         "ssl": True               # Added from override
-#     },
-#     "features": {
-#         "analytics": True         # Overridden
-#     }
-# }
+merged = deep_merge(base, override)
+assert merged == {"server": {"host": "localhost", "port": 9090}}
 ```
 
-### Merge Semantics
+Rules:
 
-- **Dictionaries**: Recursively merged (deep merge)
-- **Lists**: Replaced entirely (not merged)
-- **Scalars**: Override takes precedence
-- **Type conflicts**: Override replaces base (e.g., dict → list)
+- dictionaries merge recursively;
+- lists and scalar values replace earlier values;
+- keys absent from the override are preserved;
+- merge diagnostics are suppressed with `suppress=True`.
 
-### Advanced Usage
+::: sprigconfig.deep_merge
 
-```python
-# Merging multiple layers
-layer1 = {"a": 1, "b": {"x": 1}}
-layer2 = {"b": {"y": 2}}
-layer3 = {"b": {"z": 3}, "c": 3}
+## `ConfigSingleton`
 
-result = deep_merge(layer1, layer2)
-result = deep_merge(result, layer3)
-# {"a": 1, "b": {"x": 1, "y": 2, "z": 3}, "c": 3}
-```
-
-### When to Use
-
-`deep_merge()` is useful when:
-
-- Building configuration programmatically
-- Implementing custom config loaders
-- Merging data from multiple sources
-- Testing merge behavior
-
-**Note:** SprigConfig uses `deep_merge()` internally for all configuration merging.
-
----
-
-## ConfigSingleton
-
-A thread-safe singleton for globally shared configuration across your application.
-
-::: sprigconfig.ConfigSingleton
-    options:
-      show_root_heading: true
-      show_source: true
-      members:
-        - get_instance
-        - load
-        - reload
-        - clear
-        - is_loaded
-
-**Example:**
+`ConfigSingleton` stores one process-wide `Config` instance. Initialization is
+explicit and may occur only once:
 
 ```python
 from sprigconfig import ConfigSingleton
 
-# Load configuration once
-ConfigSingleton.load(profile="prod")
+ConfigSingleton.initialize(profile="prod", config_dir="config")
 
-# Access from anywhere in your application
-def my_function():
-    cfg = ConfigSingleton.get_instance()
-    db_host = cfg.get("database.host")
-    return db_host
 
-def another_function():
-    cfg = ConfigSingleton.get_instance()
-    # Same config instance, no reload
-    return cfg.get("app.name")
+def database_host():
+    return ConfigSingleton.get()["database.host"]
 ```
 
-### Thread Safety
+`get()` before initialization and a second `initialize()` call raise
+`ConfigLoadError`. Initialization and test cleanup use a lock; reads return the
+already-created immutable-ish `Config` object.
 
-`ConfigSingleton` is thread-safe and implements lazy initialization:
-
-```python
-import threading
-from sprigconfig import ConfigSingleton
-
-def worker():
-    # Each thread gets the same config instance
-    cfg = ConfigSingleton.get_instance()
-    print(cfg.get("app.name"))
-
-# Safe to call from multiple threads
-threads = [threading.Thread(target=worker) for _ in range(10)]
-for t in threads:
-    t.start()
-for t in threads:
-    t.join()
-```
-
-### Lifecycle Management
-
-```python
-from sprigconfig import ConfigSingleton
-
-# Load configuration
-ConfigSingleton.load(profile="dev")
-
-# Check if loaded
-if ConfigSingleton.is_loaded():
-    cfg = ConfigSingleton.get_instance()
-
-# Reload configuration (e.g., after config file changes)
-ConfigSingleton.reload(profile="dev")
-
-# Clear singleton (useful for testing)
-ConfigSingleton.clear()
-```
-
-### Web Application Pattern
-
-Common pattern for Flask/FastAPI applications:
-
-```python
-from flask import Flask
-from sprigconfig import ConfigSingleton
-
-def create_app():
-    app = Flask(__name__)
-
-    # Load config once at startup
-    ConfigSingleton.load(profile="prod")
-
-    # Use throughout request handlers
-    @app.route("/api/info")
-    def info():
-        cfg = ConfigSingleton.get_instance()
-        return {
-            "app": cfg.get("app.name"),
-            "version": cfg.get("app.version")
-        }
-
-    return app
-
-app = create_app()
-```
-
-### Testing with ConfigSingleton
-
-Clear the singleton between tests to avoid state leakage:
+The only reset API is the private `_clear_all()` test helper:
 
 ```python
 import pytest
 from sprigconfig import ConfigSingleton
 
+
 @pytest.fixture(autouse=True)
-def clear_config_singleton():
-    """Clear singleton before each test."""
-    ConfigSingleton.clear()
+def reset_config_singleton():
+    ConfigSingleton._clear_all()
     yield
-    ConfigSingleton.clear()
-
-def test_my_feature():
-    ConfigSingleton.load(profile="test")
-    cfg = ConfigSingleton.get_instance()
-    assert cfg.get("app.profile") == "test"
+    ConfigSingleton._clear_all()
 ```
 
-### When to Use ConfigSingleton
+There is currently no public reload, clear, lazy-load, or `is_loaded` method.
+Use direct `load_config()` calls when an application needs multiple independent
+configurations.
 
-✅ **Good use cases:**
-- Web applications (Flask, FastAPI, Django)
-- Long-running services
-- Applications with many modules
-- Avoiding repeated file I/O
-
-❌ **Avoid when:**
-- Writing libraries (let consumers manage config)
-- Need multiple configurations simultaneously
-- Frequent config reloading required
-- Testing with different configs in parallel
-
-### Alternative: Direct load_config()
-
-If you don't need global sharing:
-
-```python
-from sprigconfig import load_config
-
-# Simple, explicit, no singleton
-cfg = load_config(profile="dev")
-
-# Pass config explicitly to functions
-def my_function(cfg):
-    return cfg.get("database.host")
-
-result = my_function(cfg)
-```
-
----
-
-## Comparison: load_config() vs ConfigSingleton
-
-| Feature | `load_config()` | `ConfigSingleton` |
-|---------|-----------------|-------------------|
-| **Use case** | Simple scripts, explicit config | Web apps, global sharing |
-| **State** | Stateless, creates new `Config` | Singleton, cached globally |
-| **Thread safety** | Each call is independent | Shared across threads |
-| **Testing** | Easy to test with different configs | Needs cleanup between tests |
-| **Overhead** | Reads files on each call | Reads once, caches forever |
-| **Recommended for** | Libraries, scripts, tests | Applications, services |
-
----
-
-## Examples
-
-### Example 1: Manual Config Merging
-
-```python
-from sprigconfig import deep_merge
-
-# Load multiple config sources
-import yaml
-
-with open("defaults.yml") as f:
-    defaults = yaml.safe_load(f)
-
-with open("overrides.yml") as f:
-    overrides = yaml.safe_load(f)
-
-# Merge manually
-config = deep_merge(defaults, overrides)
-```
-
-### Example 2: Application-Wide Config
-
-```python
-# app/__init__.py
-from sprigconfig import ConfigSingleton
-
-def init_app():
-    ConfigSingleton.load(profile="prod")
-    print("Configuration loaded")
-
-# app/database.py
-from sprigconfig import ConfigSingleton
-
-def get_db_connection():
-    cfg = ConfigSingleton.get_instance()
-    return connect(
-        host=cfg.get("database.host"),
-        port=cfg.get("database.port")
-    )
-
-# app/api.py
-from sprigconfig import ConfigSingleton
-
-def get_api_client():
-    cfg = ConfigSingleton.get_instance()
-    return APIClient(
-        base_url=cfg.get("api.base_url"),
-        api_key=cfg.get("api.key").get()
-    )
-```
-
-### Example 3: Config Reload on Signal
-
-```python
-import signal
-from sprigconfig import ConfigSingleton
-
-def reload_config(signum, frame):
-    print("Reloading configuration...")
-    ConfigSingleton.reload()
-    print("Configuration reloaded")
-
-# Reload config on SIGHUP
-signal.signal(signal.SIGHUP, reload_config)
-
-# Initial load
-ConfigSingleton.load(profile="prod")
-
-# Send SIGHUP to reload: kill -HUP <pid>
-```
-
----
-
-## Related Documentation
-
-- [Core API](core.md) - Main configuration loading functions
-- [Configuration Guide](../configuration.md) - General configuration usage
-- [Examples](https://gitlab.com/dgw_software/sprig-config/-/tree/main/sprig-config-module/examples) - Real-world code samples
+::: sprigconfig.ConfigSingleton
+    options:
+      members:
+        - initialize
+        - get

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ When you load configuration, SprigConfig returns a `Config` object—an immutabl
 ```python
 from sprigconfig import load_config
 
-cfg = load_config(profile="dev")
+cfg = load_config(profile="dev", config_dir="config")
 ```
 
 ### Dictionary-like access
@@ -75,7 +75,7 @@ print(server.get("host", "localhost"))
 from sprigconfig import load_config
 
 # Load with profile
-cfg = load_config(profile="dev")
+cfg = load_config(profile="dev", config_dir="config")
 
 # Load with custom directory
 cfg = load_config(profile="prod", config_dir=Path("/opt/myapp/config"))
@@ -92,7 +92,7 @@ from sprigconfig import ConfigLoader
 loader = ConfigLoader(
     config_dir=Path("config"),
     profile="dev",
-    ext="yml"  # or "json", "toml"
+    config_format="yaml"  # or "json", "toml"
 )
 cfg = loader.load()
 ```
@@ -103,7 +103,8 @@ cfg = loader.load()
 |-----------|------|-------------|
 | `config_dir` | `Path` | Directory containing configuration files |
 | `profile` | `str` | Active profile (dev, test, prod, etc.) |
-| `ext` | `str` | File extension (yml, yaml, json, toml) |
+| `config_format` | `str`, optional | Format (`yml`, `yaml`, `json`, or `toml`) |
+| `schema` | dataclass type, optional | Opt-in schema validation |
 
 ---
 
@@ -143,9 +144,9 @@ host = "localhost"
 
 The format is determined by:
 
-1. **Explicit parameter:** `ConfigLoader(ext="json")`
+1. **Explicit parameter:** `ConfigLoader(config_format="json", ...)`
 2. **Environment variable:** `SPRIGCONFIG_FORMAT=json`
-3. **Default:** `yml`
+3. **Default:** `yaml`
 
 **Important:** All files in a single load must use the same format. You cannot mix YAML and JSON files.
 
@@ -178,7 +179,7 @@ export DB_HOST=db.example.com
 ```
 
 ```python
-cfg = load_config(profile="prod")
+cfg = load_config(profile="prod", config_dir="config")
 print(cfg["database.host"])  # db.example.com
 print(cfg["database.port"])  # 5432 (default used)
 ```
@@ -190,7 +191,7 @@ print(cfg["database.port"])  # 5432 (default used)
 Every loaded configuration includes metadata under `sprigconfig._meta`:
 
 ```python
-cfg = load_config(profile="dev")
+cfg = load_config(profile="dev", config_dir="config")
 
 meta = cfg["sprigconfig"]["_meta"]
 print(meta["profile"])       # dev
@@ -232,14 +233,19 @@ data = cfg.to_dict()
 data = cfg.to_dict(reveal_secrets=True)
 ```
 
-### Dumping to YAML/JSON
+### Debugging the fully assembled configuration
+
+`Config.dump()` renders the final configuration after recursive imports and
+the profile overlay have been merged, environment placeholders expanded,
+runtime metadata injected, and encrypted values wrapped. This makes it useful
+for understanding exactly what the application received.
 
 ```python
 # Dump to YAML string (secrets redacted)
 yaml_str = cfg.dump()
 
-# Dump to JSON string
-json_str = cfg.dump(output_format="json")
+# Put provenance metadata first when inspecting merge behavior
+yaml_str = cfg.dump(sprigconfig_first=True)
 
 # Write to file
 cfg.dump(Path("config-snapshot.yml"))
@@ -247,6 +253,19 @@ cfg.dump(Path("config-snapshot.yml"))
 # Dump with secrets (unsafe!)
 cfg.dump(safe=False)
 ```
+
+`Config.dump()` always emits YAML. To inspect the same assembled configuration
+as JSON, use the CLI:
+
+```bash
+sprigconfig dump \
+  --config-dir=config \
+  --profile=dev \
+  --output-format=json
+```
+
+Secrets are redacted unless explicitly revealed. Avoid `safe=False` and the
+CLI's `--secrets` flag in logs or shared build output.
 
 ---
 
@@ -293,7 +312,7 @@ SprigConfig raises `ConfigLoadError` for configuration problems:
 from sprigconfig import load_config, ConfigLoadError
 
 try:
-    cfg = load_config(profile="prod")
+    cfg = load_config(profile="prod", config_dir="config")
 except ConfigLoadError as e:
     print(f"Configuration error: {e}")
 ```
@@ -302,11 +321,14 @@ except ConfigLoadError as e:
 
 | Error | Cause |
 |-------|-------|
-| Missing file | Required file (e.g., `application-prod.yml`) not found |
 | Invalid YAML/JSON/TOML | Syntax error in configuration file |
 | Circular import | Import chain creates a cycle |
 | Missing secret key | `APP_SECRET_KEY` not set for encrypted values |
 | Invalid secret key | Key is not a valid Fernet key |
+
+Missing base or profile files currently contribute an empty layer rather than
+raising an error. Applications that require particular files should check that
+policy at startup.
 
 ---
 
@@ -338,7 +360,7 @@ port = cfg.get("server", {}).get("database", {}).get("connection", {}).get("port
 
 ```python
 def test_production_config():
-    cfg = load_config(profile="prod")
+    cfg = load_config(profile="prod", config_dir="config")
     assert cfg["sprigconfig._meta.profile"] == "prod"
     assert "application-prod.yml" in str(cfg["sprigconfig._meta.sources"])
 ```

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -1,0 +1,59 @@
+# Dependency Injection
+
+SprigConfig offers three opt-in binding patterns. Initialize
+`ConfigSingleton` before resolving any values.
+
+## Field values
+
+```python
+from sprigconfig import ConfigSingleton, ConfigValue
+
+ConfigSingleton.initialize(profile="prod", config_dir="config")
+
+
+class Service:
+    host = ConfigValue("server.host")
+    port: int = ConfigValue("server.port")
+```
+
+`ConfigValue` resolves lazily, supports defaults and basic type conversion,
+and is read-only.
+
+## Configuration sections
+
+```python
+from sprigconfig import ConfigurationProperties
+
+
+@ConfigurationProperties("database")
+class DatabaseSettings:
+    host: str
+    port: int
+
+
+settings = DatabaseSettings()
+```
+
+The decorator binds keys present in the configured section. It is a binding
+convenience, not schema validation; use `schema=` when configuration must fail
+fast on missing, unknown, or mistyped keys.
+
+## Function parameters
+
+```python
+from sprigconfig import ConfigValue, config_inject
+
+
+@config_inject
+def connect(
+    host=ConfigValue("database.host"),
+    port=ConfigValue("database.port"),
+):
+    return host, port
+```
+
+Explicit call arguments override injected defaults. Missing keys without a
+default raise `ConfigLoadError`.
+
+For implementation details, maintainers can consult
+`sprig-config-module/docs/configuration-injection.md` in the repository.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ If these principles align with your needs, SprigConfig is a good fit. Other libr
 
 ### What Python versions are supported?
 
-SprigConfig requires **Python 3.13 or later**.
+SprigConfig requires **Python 3.11 or later and earlier than Python 4**.
 
 ---
 
@@ -49,7 +49,7 @@ This is a core design principle. If profiles came from files, you'd have circula
 2. That file might be profile-specific!
 
 Runtime-driven profiles ensure:
-- Clear precedence (explicit → env var → pytest → default)
+- Explicit selection by application code
 - No ambiguity about which profile is active
 - Profiles can't accidentally override themselves
 
@@ -58,7 +58,7 @@ Runtime-driven profiles ensure:
 The active profile is always available at `app.profile`:
 
 ```python
-cfg = load_config()
+cfg = load_config(profile="dev", config_dir="config")
 print(cfg["app.profile"])  # dev, test, or prod
 ```
 
@@ -72,20 +72,19 @@ print(cfg["sprigconfig._meta.profile"])
 Yes. Use any name you want:
 
 ```python
-cfg = load_config(profile="staging")
-cfg = load_config(profile="qa")
-cfg = load_config(profile="local-docker")
+cfg = load_config(profile="staging", config_dir="config")
+cfg = load_config(profile="qa", config_dir="config")
+cfg = load_config(profile="local-docker", config_dir="config")
 ```
 
 Just create the corresponding overlay file (e.g., `application-staging.yml`).
 
-### Why does pytest automatically use the "test" profile?
+### How should tests select a profile?
 
-SprigConfig detects pytest execution and defaults to `test` profile. This prevents accidentally running tests with production settings.
+Pass it explicitly, just as production code does:
 
-Override if needed:
 ```python
-cfg = load_config(profile="dev")  # Explicit override
+cfg = load_config(profile="test", config_dir="tests/config")
 ```
 
 ---
@@ -115,7 +114,7 @@ This invented behavior would violate SprigConfig's principle of explicit, predic
 
 ```python
 # Via parameter
-loader = ConfigLoader(config_dir=Path("config"), profile="dev", ext="json")
+loader = ConfigLoader(config_dir=Path("config"), profile="dev", config_format="json")
 
 # Via environment variable
 export SPRIGCONFIG_FORMAT=json
@@ -341,7 +340,7 @@ class DatabaseConfig(BaseModel):
     port: int
     pool_size: int
 
-cfg = load_config(profile="prod")
+cfg = load_config(profile="prod", config_dir="config")
 db_config = DatabaseConfig(**cfg["database"])
 ```
 
@@ -387,7 +386,7 @@ DATABASES = {
 
 ### How do I report bugs?
 
-Open an issue at [GitLab](https://gitlab.com/dgw_software/sprig-config/-/issues) with:
+Open an issue on [GitHub](https://github.com/derikgw/sprig-config/issues) with:
 - What you expected
 - What happened
 - Relevant configuration (redacted if needed)
@@ -400,7 +399,7 @@ Format support may be considered if:
 - The format natively expresses hierarchy
 - Semantics are explicit and documented
 
-See [CONTRIBUTING.md](https://gitlab.com/dgw_software/sprig-config/-/blob/main/sprig-config-module/CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](https://github.com/derikgw/sprig-config/blob/main/CONTRIBUTING.md) for guidelines.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ Or with Poetry:
 poetry add sprig-config
 ```
 
-**Requirements:** Python 3.13 or later.
+**Requirements:** Python 3.11 or later (and earlier than Python 4).
 
 ---
 
@@ -104,7 +104,7 @@ logging:
 from sprigconfig import load_config
 
 # Load with explicit profile
-cfg = load_config(profile="dev")
+cfg = load_config(profile="dev", config_dir="config")
 
 # Access values
 print(cfg["server"]["port"])      # 9090
@@ -137,12 +137,17 @@ if "server.port" in cfg:
 
 ## Profile Selection
 
-Profiles are determined at runtime in this order:
+Profiles are explicit runtime inputs. Pass the selected profile to
+`load_config()`, `ConfigLoader`, or `ConfigSingleton.initialize()`:
 
-1. **Explicit parameter:** `load_config(profile="prod")`
-2. **Environment variable:** `APP_PROFILE=prod`
-3. **pytest context:** Automatically uses `"test"`
-4. **Default:** Falls back to `"dev"`
+```python
+profile = os.environ.get("APP_PROFILE", "dev")
+cfg = load_config(profile=profile)
+```
+
+SprigConfig does not select a profile from the environment automatically. Your
+application owns that policy, which keeps profile selection visible and
+testable.
 
 The active profile is always available in the config:
 
@@ -150,13 +155,15 @@ The active profile is always available in the config:
 print(cfg["app.profile"])  # dev, test, or prod
 ```
 
-**Important:** Never set `app.profile` in your YAML files. SprigConfig ignores it with a warning.
+`app.profile` is injected from the explicit runtime profile. A value from a
+configuration file is overwritten.
 
 ---
 
 ## Configuration Directory
 
-By default, SprigConfig looks for `config/` in your project root. You can customize this:
+Pass the configuration directory explicitly, or set `APP_CONFIG_DIR` before
+loading configuration:
 
 ### Via parameter
 
@@ -171,14 +178,8 @@ cfg = load_config(profile="dev", config_dir=Path("/opt/myapp/config"))
 export APP_CONFIG_DIR=/opt/myapp/config
 ```
 
-### Via .env file
-
-Create a `.env` file in your project root:
-
-```
-APP_CONFIG_DIR=/opt/myapp/config
-APP_PROFILE=dev
-```
+SprigConfig does not load `.env` files itself. If your application uses
+`python-dotenv` or another environment loader, invoke it before SprigConfig.
 
 ---
 
@@ -236,7 +237,7 @@ export DB_PASSWORD=secret
 ```
 
 ```python
-cfg = load_config(profile="prod")
+cfg = load_config(profile="prod", config_dir="config")
 print(cfg["database.host"])  # db.example.com
 print(cfg["database.port"])  # 5432 (default)
 ```
@@ -252,8 +253,9 @@ Now that you have basic configuration working:
 - [Profiles](profiles.md) — Deep dive into profile management
 - [Imports](imports.md) — Modularize your configuration
 - [Security](security.md) — Handle sensitive values securely
-- [Dependency Injection](../sprig-config-module/docs/configuration-injection.md) — Spring Boot-style `ConfigValue` and `@ConfigurationProperties`
-- [Dynamic Instantiation](../sprig-config-module/src/sprigconfig/instantiate.md) — Hydra-style `_target_` class instantiation
+- [Schema Validation](schema-validation.md) — Opt into typed validation
+- [Dependency Injection](dependency-injection.md) — Field, section, and function binding
+- [Dynamic Instantiation](instantiation.md) — Hydra-style `_target_` class instantiation
 
 ---
 

--- a/docs/imports.md
+++ b/docs/imports.md
@@ -251,7 +251,7 @@ All imports must be relative to the configuration directory.
 Every loaded configuration includes an import trace in its metadata:
 
 ```python
-cfg = load_config(profile="dev")
+cfg = load_config(profile="dev", config_dir="config")
 
 trace = cfg["sprigconfig._meta.import_trace"]
 for entry in trace:

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ logging:
 from sprigconfig import load_config
 
 # Load dev configuration (profile is runtime-driven)
-cfg = load_config(profile="dev")
+cfg = load_config(profile="dev", config_dir="config")
 
 print(cfg["server.port"])      # → 9090 (from dev overlay)
 print(cfg["server.host"])      # → localhost (from base)
@@ -103,8 +103,9 @@ That's it! Configuration is loaded, merged, and available via simple dotted-key 
 | **[Secure Secrets](security.md)** | Fernet-encrypted `ENC(...)` values, decrypted on-demand with lazy evaluation |
 | **[Format Support](configuration.md)** | YAML (recommended), JSON, and TOML |
 | **[CLI Tools](cli.md)** | Inspect, debug, and validate merged configuration from command line |
-| **[Dependency Injection](../sprig-config-module/docs/configuration-injection.md)** | `ConfigValue` descriptors, `@ConfigurationProperties`, and `@config_inject` decorators |
-| **[Dynamic Instantiation](../sprig-config-module/src/sprigconfig/instantiate.md)** | Hydra-style `_target_` support for instantiating classes from config |
+| **[Schema Validation](schema-validation.md)** | Opt-in dataclass validation with path-based errors |
+| **[Dependency Injection](dependency-injection.md)** | `ConfigValue` descriptors, `@ConfigurationProperties`, and `@config_inject` decorators |
+| **[Dynamic Instantiation](instantiation.md)** | Hydra-style `_target_` support for instantiating classes from config |
 | **[Provenance Tracking](configuration.md#metadata)** | Know exactly where every value came from |
 
 ---
@@ -157,19 +158,16 @@ Dive deeper into SprigConfig's behavior:
 ### 🔧 Advanced Usage
 
 For power users and framework integration:
-- **[Configuration Injection](../sprig-config-module/docs/configuration-injection.md)** — Spring Boot-style ConfigValue and @ConfigurationProperties patterns
-- **[Dependency Injection Explained](../sprig-config-module/docs/dependency-injection-explained.md)** — How Spring Boot-style DI works in Python
-- **[Secrets Best Practices](../sprig-config-module/docs/SprigConfig_ENC_BestPractices.md)** — Key generation, rotation, and operational security
+- **[Dependency Injection](dependency-injection.md)** — Field, section, and function binding
+- **[Dynamic Instantiation](instantiation.md)** — Construct objects from `_target_` configuration
+- **[Security Guide](security.md)** — Key generation, rotation, and operational security
 
 ### 👨‍💻 Contributing & Development
 
-For developers working on SprigConfig itself:
-- **[Developer Guide](../sprig-config-module/docs/README_Developer_Guide.md)** — Repository setup, testing, architecture
-- **[Release Checklist](../sprig-config-module/docs/release_checklist.md)** — Releasing new versions
-- **[Dependency Management](../sprig-config-module/docs/dependency-management.md)** — Managing Python dependencies with Poetry
-- **[GitLab CI/CD](../sprig-config-module/docs/GitLab.md)** — CI pipeline and automated testing
-- **[PyPI Publishing](../sprig-config-module/docs/PyPI.md)** — Publishing packages
-- **[Building Documentation](../sprig-config-module/docs/building_documentation.md)** — Building and deploying docs
+Maintainer runbooks live with the package source under
+`sprig-config-module/docs/`; they are intentionally separate from this public
+usage guide. Start with the repository's `CONTRIBUTING.md` and
+`sprig-config-module/docs/README_Developer_Guide.md`.
 
 ### 🔐 Operational
 
@@ -186,12 +184,10 @@ Guides for running SprigConfig in production:
 SprigConfig follows a predictable, debuggable flow:
 
 ```
-1. Profile Resolution (runtime-driven)
+1. Profile Selection (owned by the application)
    ↓
-   Explicit: load_config(profile="prod")
-   Or: APP_PROFILE=prod environment variable
-   Or: pytest context → "test"
-   Or: default → "dev"
+   Explicit: load_config(profile="prod", config_dir="config")
+   The application may read APP_PROFILE before calling SprigConfig
 
 2. File Loading & Merging
    ↓
@@ -224,6 +220,7 @@ Located in the SprigConfig source (`src/sprigconfig/`):
 | `deepmerge.py` | Deep merge algorithm with collision warnings |
 | `injection.py` | Dependency injection (`ConfigValue`, `@ConfigurationProperties`, `@config_inject`) |
 | `instantiate.py` | Dynamic class instantiation via `_target_` patterns |
+| `validation/` | Optional dataclass schema validation |
 | `exceptions.py` | Custom exceptions (ConfigLoadError, etc.) |
 | `config_singleton.py` | Thread-safe cached loader |
 | `cli.py` | Command-line interface for inspection/debugging |
@@ -272,7 +269,7 @@ How does SprigConfig compare?
 | Spring Boot style | ✅ | ⚠️ | ❌ | ❌ | ❌ | ❌ |
 | Dependency injection | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Dynamic instantiation | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Validation | ⚠️ (manual) | ❌ | ❌ | ✅ | ✅ | ❌ |
+| Validation | ✅ (opt-in) | ❌ | ❌ | ✅ | ✅ | ❌ |
 | Supported Python range | `>=3.11,<4.0` | - | - | - | - | - |
 
 **Notes on Spring Python**: Spring Python (v1.2.1) is an older project that provides IoC container and YAML/XML configuration, inspired by Spring Framework. However, it only supports Python 2.6+ (not Python 3) and lacks modern features like profile overlays, encrypted secrets, and provenance tracking. For Python developers seeking Spring-style patterns, SprigConfig offers a modern, actively-maintained alternative.
@@ -281,16 +278,15 @@ How does SprigConfig compare?
 
 ## Project Links
 
-- **GitLab** (Source of truth): [gitlab.com/dgw_software/sprig-config](https://gitlab.com/dgw_software/sprig-config)
-- **GitHub** (Mirror): [github.com/dgw_software/sprig-config](https://github.com/dgw_software/sprig-config)
+- **GitHub**: [github.com/derikgw/sprig-config](https://github.com/derikgw/sprig-config)
 - **PyPI** (Package): [pypi.org/project/sprigconfig](https://pypi.org/project/sprigconfig/)
-- **Issues & Discussions**: [GitLab Issues](https://gitlab.com/dgw_software/sprig-config/-/issues)
+- **Issues**: [GitHub Issues](https://github.com/derikgw/sprig-config/issues)
 
 ---
 
 ## License
 
-MIT License. See [LICENSE](https://gitlab.com/dgw_software/sprig-config/-/blob/main/LICENSE) for details.
+MIT License. See [LICENSE](https://github.com/derikgw/sprig-config/blob/main/sprig-config-module/LICENSE) for details.
 
 ---
 
@@ -298,9 +294,8 @@ MIT License. See [LICENSE](https://gitlab.com/dgw_software/sprig-config/-/blob/m
 
 - 📖 **Documentation** — Start with [Getting Started](getting-started.md)
 - ❓ **FAQ** — Check [Frequently Asked Questions](faq.md)
-- 🐛 **Issues** — Report bugs or request features on [GitLab Issues](https://gitlab.com/dgw_software/sprig-config/-/issues)
-- 💬 **Discussions** — Ask questions in [GitLab Discussions](https://gitlab.com/dgw_software/sprig-config/-/discussions)
-- 🤝 **Contributing** — Want to help? See [Contributing Guide](../CONTRIBUTING.md)
+- 🐛 **Issues** — Report bugs or request features on [GitHub Issues](https://github.com/derikgw/sprig-config/issues)
+- 🤝 **Contributing** — See the [Contributing Guide](https://github.com/derikgw/sprig-config/blob/main/CONTRIBUTING.md)
 
 ---
 

--- a/docs/instantiation.md
+++ b/docs/instantiation.md
@@ -1,0 +1,29 @@
+# Dynamic Instantiation
+
+`instantiate()` constructs an object from a mapping containing a Python import
+path in `_target_`.
+
+```yaml
+database:
+  _target_: myapp.adapters.PostgresAdapter
+  host: localhost
+  port: 5432
+```
+
+```python
+from sprigconfig import instantiate, load_config
+
+cfg = load_config(profile="dev", config_dir="config")
+adapter = instantiate(cfg["database"])
+```
+
+Nested `_target_` mappings are instantiated recursively by default. Use
+`_recursive_=False` to leave nested mappings untouched and
+`_convert_types_=False` to disable basic annotation-driven scalar conversion.
+
+The target must use a fully qualified `module.ClassName` path. Import errors,
+missing targets, missing required constructor parameters, and conversion
+failures raise `ConfigLoadError`.
+
+Treat configuration capable of selecting `_target_` values as trusted input;
+loading an arbitrary target imports and executes application code.

--- a/docs/merge-order.md
+++ b/docs/merge-order.md
@@ -250,7 +250,7 @@ sprigconfig dump --config-dir=config --profile=dev
 The merged config includes information about what was loaded:
 
 ```python
-cfg = load_config(profile="dev")
+cfg = load_config(profile="dev", config_dir="config")
 
 # See all source files
 for source in cfg["sprigconfig._meta.sources"]:

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -78,7 +78,7 @@ When something goes wrong in production, you need to understand your configurati
 
 SprigConfig is intentionally focused. It does not:
 
-- **Validate schemas** — Use Pydantic or similar for validation
+- **Validate schemas when requested** — Pass a dataclass type with `schema=`
 - **Manage environment variables** — Use python-dotenv or similar
 - **Handle remote configuration** — It loads local files only
 - **Support hot reloading** — Configuration is loaded once at startup
@@ -118,7 +118,7 @@ When contributing to SprigConfig, keep these principles in mind:
 4. **Choose clarity** over cleverness
 5. **Document behavior** that affects configuration semantics
 
-See [CONTRIBUTING.md](https://gitlab.com/dgw_software/sprig-config/-/blob/main/sprig-config-module/CONTRIBUTING.md) for detailed guidelines.
+See [CONTRIBUTING.md](https://github.com/derikgw/sprig-config/blob/main/CONTRIBUTING.md) for detailed guidelines.
 
 ---
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -4,352 +4,86 @@ title: Profiles
 
 # Profiles
 
-Profiles allow you to maintain environment-specific configuration without code changes. SprigConfig's profile system is **runtime-driven**—profiles are never read from configuration files.
+Profiles select an optional overlay named `application-<profile>.<ext>`.
+SprigConfig always receives the active profile explicitly at runtime; profile
+names are not read from configuration files.
 
----
-
-## How Profiles Work
-
-A profile determines which overlay file is loaded on top of the base configuration:
-
-| Profile | Overlay File |
-|---------|--------------|
-| `dev` | `application-dev.yml` |
-| `test` | `application-test.yml` |
-| `prod` | `application-prod.yml` |
-| `staging` | `application-staging.yml` |
-| `<custom>` | `application-<custom>.yml` |
-
-The base `application.yml` is always loaded first, then the profile overlay is merged on top.
-
----
-
-## Profile Selection
-
-Profiles are determined at runtime in this order:
-
-### 1. Explicit parameter (highest priority)
+## Loading a profile
 
 ```python
-cfg = load_config(profile="prod")
-```
-
-### 2. Environment variable
-
-```bash
-export APP_PROFILE=prod
-```
-
-```python
-cfg = load_config()  # Uses "prod" from environment
-```
-
-### 3. pytest context
-
-When running under pytest, SprigConfig automatically uses the `test` profile:
-
-```python
-# In test files, profile defaults to "test"
-def test_something():
-    cfg = load_config()  # Uses "test" profile
-    assert cfg["app.profile"] == "test"
-```
-
-### 4. Default
-
-If nothing else is specified, SprigConfig uses `dev`.
-
----
-
-## Profile Injection
-
-The active profile is always injected into the final configuration at `app.profile`:
-
-```python
-cfg = load_config(profile="prod")
-print(cfg["app.profile"])  # prod
-```
-
-This allows your application to know which profile is active at runtime.
-
-### Never set app.profile in files
-
-**Important:** Do not set `app.profile` in your YAML files. SprigConfig ignores it with a warning:
-
-```yaml
-# DON'T DO THIS - will be ignored
-app:
-  profile: dev
-```
-
-The runtime always determines the profile, ensuring consistency between what's loaded and what's reported.
-
----
-
-## Standard Profiles
-
-While you can use any profile name, these are the conventional profiles:
-
-### `dev` — Development
-
-Local development environment with debug settings:
-
-```yaml
-# application-dev.yml
-server:
-  port: 9090
-
-logging:
-  level: DEBUG
-
-features:
-  hot_reload: true
-  debug_toolbar: true
-```
-
-### `test` — Testing
-
-Isolated configuration for automated tests:
-
-```yaml
-# application-test.yml
-database:
-  url: sqlite:///:memory:
-
-logging:
-  level: WARNING
-
-features:
-  email: false  # Don't send real emails in tests
-```
-
-### `prod` — Production
-
-Production-hardened configuration:
-
-```yaml
-# application-prod.yml
-server:
-  host: 0.0.0.0
-
-database:
-  pool_size: 20
-  ssl: true
-
-logging:
-  level: INFO
-
-features:
-  debug_toolbar: false
-```
-
----
-
-## Production Guardrails
-
-SprigConfig includes safety checks for production:
-
-### Required production file
-
-When using the `prod` profile, `application-prod.yml` must exist. This prevents accidentally running with dev settings in production.
-
-```python
-# Raises ConfigLoadError if application-prod.yml is missing
-cfg = load_config(profile="prod")
-```
-
-### DEBUG logging protection
-
-DEBUG logging in production is blocked by default:
-
-```yaml
-# application-prod.yml
-logging:
-  level: DEBUG  # Blocked unless allow_debug_in_prod is set
-```
-
-To allow DEBUG in production (not recommended):
-
-```yaml
-# application-prod.yml
-allow_debug_in_prod: true
-logging:
-  level: DEBUG
-```
-
-### Default logging level
-
-If no logging level is specified in production, SprigConfig defaults to `INFO`.
-
----
-
-## Custom Profiles
-
-You can create profiles for any environment:
-
-```yaml
-# application-staging.yml
-database:
-  host: staging-db.example.com
-
-# application-qa.yml
-features:
-  test_accounts: true
-
-# application-local.yml
-server:
-  port: 3000
-```
-
-Load them by name:
-
-```python
-cfg = load_config(profile="staging")
-cfg = load_config(profile="qa")
-cfg = load_config(profile="local")
-```
-
----
-
-## Profile-Specific Imports
-
-Each profile can have its own imports:
-
-```yaml
-# application.yml
-server:
-  port: 8080
-imports:
-  - common/logging.yml
-  - common/security.yml
-
-# application-dev.yml
-imports:
-  - dev/mock-services.yml
-  - dev/debug-settings.yml
-
-# application-prod.yml
-imports:
-  - prod/monitoring.yml
-  - prod/security-hardening.yml
-```
-
-Import order:
-1. Base file
-2. Base imports
-3. Profile file
-4. Profile imports
-
-See [Merge Order](merge-order.md) for details.
-
----
-
-## Checking Profile at Runtime
-
-Use the injected `app.profile` to make runtime decisions:
-
-```python
-cfg = load_config()
-
-if cfg["app.profile"] == "prod":
-    # Production-specific initialization
-    setup_monitoring()
-    enable_rate_limiting()
-elif cfg["app.profile"] == "dev":
-    # Development helpers
-    enable_debug_toolbar()
-```
-
-Or access from metadata:
-
-```python
-profile = cfg["sprigconfig._meta.profile"]
-```
-
----
-
-## Testing with Profiles
-
-### Explicit test profile
-
-```python
-def test_production_config():
-    cfg = load_config(profile="prod", config_dir=Path("tests/config"))
-    assert cfg["database.ssl"] == True
-```
-
-### Using pytest fixtures
-
-```python
-import pytest
+from pathlib import Path
 from sprigconfig import load_config
 
-@pytest.fixture
-def prod_config():
-    return load_config(profile="prod")
-
-def test_pool_size(prod_config):
-    assert prod_config["database.pool_size"] >= 10
+cfg = load_config(profile="dev", config_dir=Path("config"))
 ```
 
-### Environment variable in tests
+If your application selects profiles through an environment variable, resolve
+that policy before calling SprigConfig:
 
 ```python
 import os
 
-def test_with_custom_profile(monkeypatch):
-    monkeypatch.setenv("APP_PROFILE", "staging")
-    cfg = load_config()
-    assert cfg["app.profile"] == "staging"
+profile = os.environ.get("APP_PROFILE", "dev")
+cfg = load_config(profile=profile, config_dir="config")
 ```
 
----
+`APP_PROFILE` is a useful application convention, but SprigConfig does not read
+it automatically.
 
-## Best Practices
+## Files and merge behavior
 
-### Keep base complete
+For `profile="prod"` in YAML mode, the loader processes:
 
-Your `application.yml` should define all keys with sensible defaults. Profiles should only override what's different.
+1. `application.yaml` or `application.yml`;
+2. its recursive imports;
+3. `application-prod.yaml` or `application-prod.yml`, when present;
+4. the overlay's recursive imports.
+
+Later values override earlier values through the standard deep-merge rules.
+Profile names are not restricted to `dev`, `test`, and `prod`.
 
 ```yaml
-# application.yml - complete defaults
+# application.yml
 server:
   host: localhost
   port: 8080
-  timeout: 30
-  max_connections: 100
 
-# application-prod.yml - only overrides
-server:
-  host: 0.0.0.0
-  max_connections: 1000
-```
-
-### Don't duplicate across profiles
-
-If a value is the same in dev and test, keep it in the base file.
-
-### Use environment variables for secrets
-
-Don't hardcode credentials in profile files:
-
-```yaml
 # application-prod.yml
-database:
-  password: ${DB_PASSWORD}  # Or use ENC() for encrypted values
+server:
+  host: api.example.com
 ```
 
-### Test all profiles
+The resulting `server.port` remains `8080`, while `server.host` becomes
+`api.example.com`.
 
-Ensure each profile loads successfully:
+## Missing overlays
+
+A profile overlay is optional. If `application-<profile>` does not exist, the
+base configuration still loads and the requested profile is injected as
+`app.profile`. Enforce a required production overlay in application startup if
+that is part of your deployment policy.
+
+## Runtime profile metadata
+
+The selected profile is available in two generated locations:
 
 ```python
-@pytest.mark.parametrize("profile", ["dev", "test", "prod"])
-def test_profile_loads(profile):
-    cfg = load_config(profile=profile)
-    assert cfg["app.profile"] == profile
+assert cfg["app.profile"] == "prod"
+assert cfg["sprigconfig._meta.profile"] == "prod"
 ```
 
----
+A file-provided `app.profile` value is overwritten by the runtime argument.
+
+## Testing profiles
+
+Tests should pass profiles explicitly:
+
+```python
+def test_production_configuration(tmp_path):
+    cfg = load_config(profile="prod", config_dir=tmp_path)
+    assert cfg["app.profile"] == "prod"
+```
+
+There is no automatic pytest profile selection in the public loader API.
 
 [← Back to Documentation](index.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -110,7 +110,9 @@ Configuration is loaded once at startup. Hot reloading introduces complexity and
 
 ### Schema validation
 
-Use Pydantic or similar for validation after loading. SprigConfig focuses on loading and merging.
+Dataclass schema validation is now available as an opt-in loader feature. See
+[Schema Validation](schema-validation.md). Rich constraints such as ranges and
+patterns remain future work.
 
 ---
 
@@ -170,7 +172,7 @@ Use Pydantic or similar for validation after loading. SprigConfig focuses on loa
 - Secure lazy secrets
 - CLI tooling
 
-See [CHANGELOG](https://gitlab.com/dgw_software/sprig-config/-/blob/main/CHANGELOG.md) for complete version history.
+See [CHANGELOG](https://github.com/derikgw/sprig-config/blob/main/CHANGELOG.md) for complete version history.
 
 ---
 
@@ -191,7 +193,7 @@ Open an issue describing:
 - Ensure backward compatibility
 - Include tests for new behavior
 
-See [CONTRIBUTING.md](https://gitlab.com/dgw_software/sprig-config/-/blob/main/sprig-config-module/CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](https://github.com/derikgw/sprig-config/blob/main/CONTRIBUTING.md) for guidelines.
 
 ---
 

--- a/docs/schema-validation.md
+++ b/docs/schema-validation.md
@@ -1,0 +1,97 @@
+---
+title: Schema Validation
+---
+
+# Schema Validation
+
+Schema validation is optional. Existing applications that omit `schema=` use
+the same loading behavior as before, even when configuration values do not
+match annotations elsewhere in application code.
+
+## Define a schema
+
+Use standard dataclasses for nested configuration sections:
+
+```python
+from dataclasses import dataclass, field
+
+
+@dataclass
+class DatabaseSchema:
+    host: str
+    port: int
+
+
+@dataclass
+class AppSchema:
+    database: DatabaseSchema
+    features: list[str] = field(default_factory=list)
+```
+
+## Enable validation
+
+Pass the dataclass type—not an instance—to either public loading API:
+
+```python
+from pathlib import Path
+from sprigconfig import ConfigLoader, load_config
+
+cfg = load_config(
+    profile="prod",
+    config_dir=Path("config"),
+    schema=AppSchema,
+)
+
+# Equivalent loader API
+cfg = ConfigLoader(
+    config_dir=Path("config"),
+    profile="prod",
+    schema=AppSchema,
+).load()
+```
+
+Validation runs after imports and the profile overlay are merged, but before
+SprigConfig injects `app.profile`, `sprigconfig._meta`, and `LazySecret`
+wrappers. Generated sections therefore do not belong in the schema unless they
+already exist in the user's merged configuration.
+
+## Validation behavior
+
+The validator checks:
+
+- required dataclass fields;
+- unknown keys at every dataclass level;
+- nested dataclasses;
+- `Any`, unions such as `int | None`, lists, and dictionaries;
+- strict runtime types, including treating `bool` as distinct from `int`.
+
+Defaulted fields may be absent from configuration. Defaults are used only to
+decide whether a field is required; validation does not instantiate the
+dataclass or insert default values into the returned configuration.
+
+## Errors
+
+Failures raise `ConfigValidationError`, which is also a `ConfigLoadError`:
+
+```python
+from sprigconfig import ConfigValidationError
+
+try:
+    cfg = load_config(profile="prod", config_dir="config", schema=AppSchema)
+except ConfigValidationError as error:
+    print(error)
+```
+
+Diagnostics use dotted paths, for example:
+
+```text
+Missing required key 'database.host'.
+Type mismatch at 'database.port': expected int, got str.
+Unknown key 'database.driver'.
+```
+
+## Current scope
+
+The initial validator does not enforce enum membership, numeric ranges,
+patterns, tuples, sets, or arbitrary third-party model types. Unsupported
+typing constructs fail validation instead of being silently accepted.

--- a/docs/security.md
+++ b/docs/security.md
@@ -172,7 +172,7 @@ database:
 Encrypted values become `LazySecret` objects:
 
 ```python
-cfg = load_config(profile="prod")
+cfg = load_config(profile="prod", config_dir="config")
 
 # Returns LazySecret, not the plaintext
 secret = cfg["database"]["password"]
@@ -211,7 +211,7 @@ Note: Python's garbage collection makes guaranteed memory cleanup impossible.
 Secrets are redacted in dumps and serialization:
 
 ```python
-cfg = load_config(profile="prod")
+cfg = load_config(profile="prod", config_dir="config")
 
 # Redacted output
 print(cfg.to_dict())
@@ -322,7 +322,7 @@ deploy:
 from sprigconfig import load_config, ConfigLoadError
 
 try:
-    cfg = load_config(profile="prod")
+    cfg = load_config(profile="prod", config_dir="config")
     password = cfg["database"]["password"].get()
 except ConfigLoadError as e:
     if "Fernet key" in str(e):

--- a/sprig-config-module/docs/README.md
+++ b/sprig-config-module/docs/README.md
@@ -1,0 +1,50 @@
+# Maintainer Documentation
+
+This directory contains documentation for people developing and releasing
+SprigConfig. User-facing documentation is maintained in the repository-level
+`docs/` directory. GitHub Pages currently publishes that directory with Jekyll;
+MkDocs provides local preview and strict documentation validation.
+
+## Active maintainer guides
+
+- `README_Developer_Guide.md` — local setup, architecture, and contribution flow
+- `dependency-management.md` — dependency and security update workflow
+- `release_checklist.md` — release verification checklist
+- `PyPI.md` — package publishing configuration and procedures
+- `GitLab.md` — remaining GitLab pipeline behavior during the GitHub migration
+- `building_documentation.md` — documentation tooling and publishing
+- `git_skip_worktree_for_test_config_files.md` — specialized test-fixture workflow
+
+These operational guides should be checked against CI configuration whenever
+the workflows change.
+
+## Detailed implementation references
+
+- `configuration-injection.md`
+- `dependency-injection-explained.md`
+- `SprigConfig_ENC_BestPractices.md`
+- `migration_guide.md`
+
+Concise usage instructions belong in the public `docs/` tree. These longer
+documents are implementation or migration references and should not duplicate
+the public API contract.
+
+## Historical artifacts
+
+Files named `gitlab-issue-*` and `gitlab-mr-*` are snapshots of past issue and
+merge-request descriptions. They are not current product documentation and
+should be moved to issue trackers or an archive in a future cleanup.
+
+`AI_Info.md` and `code-metrics.md` record development process and point-in-time
+analysis. Treat them as project records, not usage guidance.
+
+## Documentation rules
+
+1. The code and executable tests define behavior.
+2. Public APIs and examples belong under the root `docs/` directory.
+3. Maintainer procedures belong here and should link to workflow files rather
+   than restating them line by line.
+4. Design proposals under `docs/AOP/`, per-module Markdown under `src/`, and
+   per-test Markdown under `tests/` are not public API documentation.
+5. Run `poetry run mkdocs build --strict` and the full test suite before merging
+   documentation changes.

--- a/sprig-config-module/docs/building_documentation.md
+++ b/sprig-config-module/docs/building_documentation.md
@@ -197,21 +197,28 @@ poetry run mkdocs build --strict
 
 ## Deploying Documentation
 
-### GitHub Pages (Automated)
+### GitHub Pages (current deployment)
 
-Documentation is automatically deployed to GitHub Pages on push to `main`:
+GitHub Pages is configured in the repository settings to publish from the
+`main` branch's `/docs` directory. GitHub's built-in
+`pages-build-deployment` workflow renders that directory with Jekyll using
+`docs/_config.yml`.
 
-```bash
-# Manual deployment (if needed)
-poetry run mkdocs gh-deploy
-```
+There is no checked-in GitHub Actions workflow for documentation deployment,
+and there is no `gh-pages` branch. `mkdocs build --strict` remains the local
+validation and preview command, but its generated site is not the artifact
+currently served by GitHub Pages.
 
-This will:
-1. Build the documentation
-2. Push to `gh-pages` branch
-3. Trigger GitHub Pages deployment
+If the project later switches production deployment to MkDocs, add a dedicated
+GitHub Actions Pages workflow and change the repository Pages source to GitHub
+Actions. Do not use `mkdocs gh-deploy` while Pages is configured for
+`main:/docs`.
 
 ### GitLab Pages
+
+The current `.gitlab-ci.yml` `pages` job publishes the dependency-vulnerability
+dashboard, not this MkDocs documentation site. The following is an example of
+how a documentation deployment could be configured; it is not the active job:
 
 For GitLab Pages, add to `.gitlab-ci.yml`:
 

--- a/sprig-config-module/mkdocs.yml
+++ b/sprig-config-module/mkdocs.yml
@@ -1,8 +1,12 @@
 site_name: SprigConfig Documentation
 site_description: Spring Boot-style configuration for Python applications
-site_url: https://dgw-software.gitlab.io/sprig-config/
-repo_url: https://gitlab.com/dgw_software/sprig-config
-repo_name: GitLab
+site_url: https://derikgw.github.io/sprig-config/
+repo_url: https://github.com/derikgw/sprig-config
+repo_name: GitHub
+docs_dir: ../docs
+exclude_docs: |
+  snyk-gitlab-setup.md
+  AOP/
 
 theme:
   name: material
@@ -18,37 +22,31 @@ theme:
     - search.highlight
 
 nav:
-  - Home: ../docs/index.md
+  - Home: index.md
   - Getting Started:
-      - Installation & Quickstart: ../docs/getting-started.md
-      - Configuration Guide: ../docs/configuration.md
+      - Installation & Quickstart: getting-started.md
+      - Configuration Guide: configuration.md
   - Core Concepts:
-      - Profiles: ../docs/profiles.md
-      - Imports: ../docs/imports.md
-      - Merge Semantics: ../docs/merge-order.md
+      - Profiles: profiles.md
+      - Imports: imports.md
+      - Merge Semantics: merge-order.md
   - Features:
-      - Security & Secrets: ../docs/security.md
-      - Command Line Interface: ../docs/cli.md
+      - Schema Validation: schema-validation.md
+      - Security & Secrets: security.md
+      - Command Line Interface: cli.md
+  - Advanced:
+      - Dependency Injection: dependency-injection.md
+      - Dynamic Instantiation: instantiation.md
   - API Reference:
-      - Overview: ../docs/api/index.md
-      - Core API: ../docs/api/core.md
-      - Secrets: ../docs/api/secrets.md
-      - Utilities: ../docs/api/utilities.md
-      - Exceptions: ../docs/api/exceptions.md
+      - Overview: api/index.md
+      - Core API: api/core.md
+      - Secrets: api/secrets.md
+      - Utilities: api/utilities.md
+      - Exceptions: api/exceptions.md
   - Reference:
-      - FAQ: ../docs/faq.md
-      - Design Philosophy: ../docs/philosophy.md
-      - Roadmap: ../docs/roadmap.md
-      - Migration Guide: docs/migration_guide.md
-  - Developer Guides:
-      - Overview: docs/README_Developer_Guide.md
-      - Release Checklist: docs/release_checklist.md
-      - Secret Best Practices: docs/SprigConfig_ENC_BestPractices.md
-      - GitLab CI/CD: docs/GitLab.md
-      - PyPI Publishing: docs/PyPI.md
-      - Snyk Setup: docs/snyk-gitlab-setup.md
-      - Git Workflows: docs/git_skip_worktree_for_test_config_files.md
-      - AI Assistant Guide: docs/AI_Info.md
+      - FAQ: faq.md
+      - Design Philosophy: philosophy.md
+      - Roadmap: roadmap.md
 
 markdown_extensions:
   - admonition
@@ -88,9 +86,9 @@ plugins:
 
 extra:
   social:
-    - icon: fontawesome/brands/gitlab
-      link: https://gitlab.com/dgw_software/sprig-config
+    - icon: fontawesome/brands/github
+      link: https://github.com/derikgw/sprig-config
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/sprigconfig/
 
-copyright: Copyright &copy; 2025 SprigConfig Contributors
+copyright: Copyright &copy; 2026 SprigConfig Contributors

--- a/sprig-config-module/src/sprigconfig/__init__.py
+++ b/sprig-config-module/src/sprigconfig/__init__.py
@@ -30,7 +30,7 @@ from .config import Config
 from .config_loader import ConfigLoader
 from .config_singleton import ConfigSingleton
 from .deepmerge import deep_merge
-from .exceptions import ConfigLoadError
+from .exceptions import ConfigLoadError, ConfigValidationError
 
 # Dependency Injection
 from .injection import (
@@ -44,7 +44,7 @@ from .instantiate import instantiate
 # Backward-compatible load_config()
 # ---------------------------------------------------------------------------
 
-def load_config(*, profile: str, config_dir: Path = None):
+def load_config(*, profile: str, config_dir: Path = None, schema: type | None = None):
     """
     Legacy-compatible convenience function.
 
@@ -58,7 +58,7 @@ def load_config(*, profile: str, config_dir: Path = None):
 
     This function delegates entirely to ConfigLoader.
     """
-    loader = ConfigLoader(config_dir=config_dir, profile=profile)
+    loader = ConfigLoader(config_dir=config_dir, profile=profile, schema=schema)
     cfg = loader.load()
 
     if not isinstance(cfg, Config):
@@ -74,6 +74,7 @@ __all__ = [
     "ConfigSingleton",
     "deep_merge",
     "ConfigLoadError",
+    "ConfigValidationError",
     "load_config",
     # Dependency Injection
     "ConfigValue",

--- a/sprig-config-module/src/sprigconfig/config.py
+++ b/sprig-config-module/src/sprigconfig/config.py
@@ -60,7 +60,7 @@ class Config(Mapping):
         """
         Support:
             cfg["a.b.c"]
-            cfg["a"]["b"]["c"]
+            ``cfg["a"]["b"]["c"]``
         Strict: raises KeyError if any part is missing.
         """
         if isinstance(key, str) and "." in key:

--- a/sprig-config-module/src/sprigconfig/config_loader.py
+++ b/sprig-config-module/src/sprigconfig/config_loader.py
@@ -25,6 +25,7 @@ from .lazy_secret import LazySecret
 from .exceptions import ConfigLoadError
 from .deepmerge import deep_merge
 from .parsers import YamlParser, JsonParser, TomlParser
+from .validation import validate_schema
 
 # ======================================================================
 # CONSTANTS
@@ -86,6 +87,7 @@ class ConfigLoader:
         profile: str,
         *,
         config_format: Optional[str] = None,
+        schema: Optional[type] = None,
     ):
         if config_dir is None:
             env_dir = os.getenv("APP_CONFIG_DIR")
@@ -106,6 +108,7 @@ class ConfigLoader:
 
         self.format = self._normalize_format(raw_format)
         self.parser = PARSERS[self.format]
+        self.schema = schema
 
         # Import + merge tracking
         self._merge_trace: List[str] = []
@@ -173,6 +176,9 @@ class ConfigLoader:
         # 3. Merge
         # --------------------------------------------------
         merged = deep_merge(base_data, profile_data, suppress=suppress)
+
+        if self.schema is not None:
+            validate_schema(merged, self.schema)
 
         merged.setdefault("app", {})["profile"] = self.profile
 

--- a/sprig-config-module/src/sprigconfig/deepmerge.py
+++ b/sprig-config-module/src/sprigconfig/deepmerge.py
@@ -21,7 +21,9 @@ from typing import Any, Dict
 logger = logging.getLogger(__name__)
 
 
-def deep_merge(base: Dict[str, Any], override: Dict[str, Any], *, suppress=False, path=""):
+def deep_merge(
+    base: Dict[str, Any], override: Dict[str, Any], *, suppress=False, path=""
+) -> Dict[str, Any]:
     """
     Recursively deep-merge override → base, modifying base in-place.
 

--- a/sprig-config-module/src/sprigconfig/exceptions.py
+++ b/sprig-config-module/src/sprigconfig/exceptions.py
@@ -1,3 +1,7 @@
 # src/sprigconfig/exceptions.py
 class ConfigLoadError(Exception):
     """Raised when configuration fails to load or parse."""
+
+
+class ConfigValidationError(ConfigLoadError):
+    """Raised when loaded configuration fails schema validation."""

--- a/sprig-config-module/src/sprigconfig/validation/__init__.py
+++ b/sprig-config-module/src/sprigconfig/validation/__init__.py
@@ -1,0 +1,3 @@
+from .validator import validate_schema
+
+__all__ = ["validate_schema"]

--- a/sprig-config-module/src/sprigconfig/validation/validator.py
+++ b/sprig-config-module/src/sprigconfig/validation/validator.py
@@ -1,0 +1,119 @@
+from dataclasses import MISSING, fields, is_dataclass
+from types import UnionType
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+from ..exceptions import ConfigValidationError
+
+
+def validate_schema(config: dict[str, Any], schema: type) -> None:
+    if not isinstance(config, dict):
+        raise ConfigValidationError("Schema validation requires a mapping configuration root.")
+    if not is_dataclass(schema):
+        raise ConfigValidationError(
+            "Schema must be a dataclass type for validation."
+        )
+    _validate_dataclass(config, schema, path="")
+
+
+def _validate_dataclass(value: dict[str, Any], schema_type: type, *, path: str) -> None:
+    if not isinstance(value, dict):
+        location = path or "<root>"
+        raise ConfigValidationError(
+            f"Type mismatch at '{location}': expected mapping for {schema_type.__name__}, got {type(value).__name__}."
+        )
+
+    schema_fields = fields(schema_type)
+    type_hints = get_type_hints(schema_type)
+
+    expected_keys = {f.name for f in schema_fields}
+    for key in value.keys():
+        if key not in expected_keys:
+            dotted = _join_path(path, key)
+            raise ConfigValidationError(f"Unknown key '{dotted}'.")
+
+    for field in schema_fields:
+        dotted = _join_path(path, field.name)
+        required = field.default is MISSING and field.default_factory is MISSING
+
+        if field.name not in value:
+            if required:
+                raise ConfigValidationError(f"Missing required key '{dotted}'.")
+            continue
+
+        expected_type = type_hints.get(field.name, Any)
+        _validate_value(value[field.name], expected_type, path=dotted)
+
+
+def _validate_value(value: Any, expected_type: Any, *, path: str) -> None:
+    if expected_type is Any:
+        return
+
+    origin = get_origin(expected_type)
+    args = get_args(expected_type)
+
+    if origin in (Union, UnionType):
+        for candidate in args:
+            try:
+                _validate_value(value, candidate, path=path)
+                return
+            except ConfigValidationError:
+                continue
+        _raise_type_mismatch(path, expected_type, value)
+
+    if is_dataclass(expected_type):
+        _validate_dataclass(value, expected_type, path=path)
+        return
+
+    if origin in (list,):
+        if not isinstance(value, list):
+            _raise_type_mismatch(path, expected_type, value)
+        item_type = args[0] if args else Any
+        for idx, item in enumerate(value):
+            _validate_value(item, item_type, path=f"{path}[{idx}]")
+        return
+
+    if origin in (dict,):
+        if not isinstance(value, dict):
+            _raise_type_mismatch(path, expected_type, value)
+        key_type = args[0] if len(args) > 0 else Any
+        val_type = args[1] if len(args) > 1 else Any
+        for key, item in value.items():
+            _validate_value(key, key_type, path=f"{path}.<key>")
+            _validate_value(item, val_type, path=_join_path(path, str(key)))
+        return
+
+    if isinstance(expected_type, type):
+        if expected_type is bool:
+            if not isinstance(value, bool):
+                _raise_type_mismatch(path, expected_type, value)
+            return
+        if expected_type is int:
+            if not isinstance(value, int) or isinstance(value, bool):
+                _raise_type_mismatch(path, expected_type, value)
+            return
+        if not isinstance(value, expected_type):
+            _raise_type_mismatch(path, expected_type, value)
+        return
+
+    # If typing construct is unsupported, do not silently accept unknown structures.
+    _raise_type_mismatch(path, expected_type, value)
+
+
+def _raise_type_mismatch(path: str, expected_type: Any, value: Any) -> None:
+    raise ConfigValidationError(
+        f"Type mismatch at '{path}': expected {_type_name(expected_type)}, got {type(value).__name__}."
+    )
+
+
+def _type_name(expected_type: Any) -> str:
+    origin = get_origin(expected_type)
+    if origin is None:
+        return getattr(expected_type, "__name__", str(expected_type))
+    args = ", ".join(_type_name(arg) for arg in get_args(expected_type))
+    return f"{origin.__name__}[{args}]"
+
+
+def _join_path(path: str, key: str) -> str:
+    if not path:
+        return key
+    return f"{path}.{key}"

--- a/sprig-config-module/src/sprigconfig/validation/validator.py
+++ b/sprig-config-module/src/sprigconfig/validation/validator.py
@@ -8,7 +8,7 @@ from ..exceptions import ConfigValidationError
 def validate_schema(config: dict[str, Any], schema: type) -> None:
     if not isinstance(config, dict):
         raise ConfigValidationError("Schema validation requires a mapping configuration root.")
-    if not is_dataclass(schema):
+    if not isinstance(schema, type) or not is_dataclass(schema):
         raise ConfigValidationError(
             "Schema must be a dataclass type for validation."
         )

--- a/sprig-config-module/tests/test_validation.md
+++ b/sprig-config-module/tests/test_validation.md
@@ -1,0 +1,15 @@
+## Purpose
+
+Validates opt-in schema validation behavior for `ConfigLoader` using typed dataclass schemas.
+
+## Coverage
+
+- Successful validation against a matching schema.
+- Missing required key detection.
+- Type mismatch detection with dotted-path diagnostics.
+- Unknown key rejection.
+- Nested path error reporting.
+
+## Why this matters
+
+Schema validation should fail fast with precise diagnostics while remaining fully opt-in and backward-compatible for existing users who do not provide a schema.

--- a/sprig-config-module/tests/test_validation.md
+++ b/sprig-config-module/tests/test_validation.md
@@ -9,6 +9,16 @@ Validates opt-in schema validation behavior for `ConfigLoader` using typed datac
 - Type mismatch detection with dotted-path diagnostics.
 - Unknown key rejection.
 - Nested path error reporting.
+- Backward-compatible loading when no schema is supplied.
+- Proof that the validator is never invoked on the legacy no-schema path.
+- A config value that conflicts with a code-side schema type still loads when
+  `schema=` is omitted.
+- Validation through both `ConfigLoader` and `load_config`.
+- Optional/defaulted fields and typed list/dict values.
+- Validation after imports and profile overlays are merged.
+- Runtime-generated metadata outside the user schema.
+- Format parity across YAML, JSON, and TOML.
+- Clear rejection of non-dataclass types and dataclass instances.
 
 ## Why this matters
 

--- a/sprig-config-module/tests/test_validation.py
+++ b/sprig-config-module/tests/test_validation.py
@@ -1,10 +1,12 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from sprigconfig import ConfigLoader
+from sprigconfig import ConfigLoader, load_config
 from sprigconfig.exceptions import ConfigValidationError
+import sprigconfig.config_loader as config_loader_module
 
 
 def _write_yaml(path: Path, content: str) -> None:
@@ -121,3 +123,200 @@ database:
         ConfigLoader(config_dir=tmp_path, profile="dev", schema=RootSchema).load()
 
     assert "Type mismatch at 'database.port'" in str(exc.value)
+
+
+def test_existing_apps_remain_unrestricted_without_schema(tmp_path):
+    """Legacy callers must not acquire validation constraints by upgrading."""
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+arbitrary:
+  keys:
+    added_by_an_old_app: true
+mixed_values:
+  - 1
+  - text
+  - nested: value
+""",
+    )
+
+    cfg = ConfigLoader(config_dir=tmp_path, profile="dev").load()
+
+    assert cfg.get("arbitrary.keys.added_by_an_old_app") is True
+    assert cfg.get("mixed_values")[2].get("nested") == "value"
+    assert cfg.get("app.profile") == "dev"
+    assert cfg.get("sprigconfig._meta.profile") == "dev"
+
+
+def test_legacy_path_never_invokes_validator(tmp_path, monkeypatch):
+    _write_yaml(tmp_path / "application.yml", "legacy: untouched\n")
+
+    def fail_if_called(config, schema):
+        raise AssertionError("validator must remain opt-in")
+
+    monkeypatch.setattr(config_loader_module, "validate_schema", fail_if_called)
+
+    cfg = ConfigLoader(config_dir=tmp_path, profile="dev").load()
+
+    assert cfg.get("legacy") == "untouched"
+
+
+@dataclass
+class LegacyTypeSchema:
+    retries: int
+
+
+def test_legacy_load_ignores_code_type_mismatch_without_schema(tmp_path):
+    """A code-side schema has no effect unless the caller explicitly opts in."""
+    _write_yaml(tmp_path / "application.yml", 'retries: "not-an-integer"\n')
+
+    cfg = ConfigLoader(config_dir=tmp_path, profile="dev").load()
+
+    assert cfg.get("retries") == "not-an-integer"
+
+
+def test_legacy_load_config_signature_still_works_without_schema(tmp_path):
+    _write_yaml(tmp_path / "application.yml", "legacy: still-works\n")
+
+    cfg = load_config(profile="dev", config_dir=tmp_path)
+
+    assert cfg.get("legacy") == "still-works"
+
+
+def test_load_config_convenience_api_accepts_schema(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+app:
+  name: TestApp
+  debug_mode: true
+database:
+  host: localhost
+  port: 5432
+""",
+    )
+
+    cfg = load_config(profile="dev", config_dir=tmp_path, schema=RootSchema)
+
+    assert cfg.get("database.host") == "localhost"
+
+
+@dataclass
+class FlexibleSchema:
+    required: str
+    optional: int | None = None
+    labels: list[str] = field(default_factory=list)
+    attributes: dict[str, int] = field(default_factory=dict)
+    unrestricted: Any = None
+
+
+def test_defaults_optionals_and_typed_collections(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+required: present
+optional: null
+labels: [one, two]
+attributes:
+  retries: 3
+unrestricted:
+  old_app_shape: [anything, 42]
+""",
+    )
+
+    cfg = ConfigLoader(config_dir=tmp_path, profile="dev", schema=FlexibleSchema).load()
+
+    assert cfg.get("optional") is None
+    assert cfg.get("labels") == ["one", "two"]
+    assert cfg.get("attributes.retries") == 3
+
+
+def test_defaulted_schema_fields_may_be_absent(tmp_path):
+    _write_yaml(tmp_path / "application.yml", "required: present\n")
+
+    cfg = ConfigLoader(config_dir=tmp_path, profile="dev", schema=FlexibleSchema).load()
+
+    assert cfg.get("required") == "present"
+    assert "optional" not in cfg
+
+
+@dataclass
+class ImportedSchema:
+    shared: dict[str, str]
+    service: dict[str, int | str]
+
+
+def test_validation_runs_after_import_and_profile_merges(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+imports: [imports/common]
+service:
+  name: api
+  workers: 1
+""",
+    )
+    (tmp_path / "imports").mkdir()
+    _write_yaml(tmp_path / "imports" / "common.yml", "shared:\n  region: us-east\n")
+    _write_yaml(tmp_path / "application-prod.yml", "service:\n  workers: 4\n")
+
+    # Imports are control syntax and are removed before schema validation.
+    cfg = ConfigLoader(config_dir=tmp_path, profile="prod", schema=ImportedSchema).load()
+
+    assert cfg.get("shared.region") == "us-east"
+    assert cfg.get("service.workers") == 4
+
+
+@dataclass
+class MinimalSchema:
+    value: str
+
+
+def test_runtime_generated_sections_do_not_have_to_be_in_schema(tmp_path):
+    _write_yaml(tmp_path / "application.yml", "value: accepted\n")
+
+    cfg = ConfigLoader(config_dir=tmp_path, profile="dev", schema=MinimalSchema).load()
+
+    assert cfg.get("app.profile") == "dev"
+    assert cfg.get("sprigconfig._meta.profile") == "dev"
+
+
+@pytest.mark.parametrize(
+    ("config_format", "filename", "content"),
+    [
+        ("yaml", "application.yml", "value: accepted\n"),
+        ("json", "application.json", '{"value": "accepted"}'),
+        ("toml", "application.toml", 'value = "accepted"'),
+    ],
+)
+def test_schema_validation_is_format_agnostic(
+    tmp_path, config_format, filename, content
+):
+    _write_yaml(tmp_path / filename, content)
+
+    cfg = ConfigLoader(
+        config_dir=tmp_path,
+        profile="dev",
+        config_format=config_format,
+        schema=MinimalSchema,
+    ).load()
+
+    assert cfg.get("value") == "accepted"
+
+
+def test_schema_must_be_a_dataclass_type(tmp_path):
+    _write_yaml(tmp_path / "application.yml", "value: accepted\n")
+
+    with pytest.raises(ConfigValidationError, match="Schema must be a dataclass type"):
+        ConfigLoader(config_dir=tmp_path, profile="dev", schema=dict).load()
+
+
+def test_dataclass_instance_is_rejected_as_schema(tmp_path):
+    _write_yaml(tmp_path / "application.yml", "value: accepted\n")
+
+    with pytest.raises(ConfigValidationError, match="Schema must be a dataclass type"):
+        ConfigLoader(
+            config_dir=tmp_path,
+            profile="dev",
+            schema=MinimalSchema("accepted"),
+        ).load()

--- a/sprig-config-module/tests/test_validation.py
+++ b/sprig-config-module/tests/test_validation.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from sprigconfig import ConfigLoader
+from sprigconfig.exceptions import ConfigValidationError
+
+
+def _write_yaml(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+@dataclass
+class DatabaseSchema:
+    host: str
+    port: int
+
+
+@dataclass
+class AppSectionSchema:
+    name: str
+    debug_mode: bool
+
+
+@dataclass
+class RootSchema:
+    app: AppSectionSchema
+    database: DatabaseSchema
+
+
+def test_schema_validation_success(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+app:
+  name: TestApp
+  debug_mode: true
+database:
+  host: localhost
+  port: 5432
+""",
+    )
+
+    cfg = ConfigLoader(config_dir=tmp_path, profile="dev", schema=RootSchema).load()
+    assert cfg.get("app.name") == "TestApp"
+    assert cfg.get("database.port") == 5432
+
+
+def test_schema_validation_missing_required_field(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+app:
+  name: TestApp
+database:
+  host: localhost
+  port: 5432
+""",
+    )
+
+    with pytest.raises(ConfigValidationError) as exc:
+        ConfigLoader(config_dir=tmp_path, profile="dev", schema=RootSchema).load()
+
+    assert "Missing required key 'app.debug_mode'" in str(exc.value)
+
+
+def test_schema_validation_type_mismatch(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+app:
+  name: TestApp
+  debug_mode: "not-bool"
+database:
+  host: localhost
+  port: 5432
+""",
+    )
+
+    with pytest.raises(ConfigValidationError) as exc:
+        ConfigLoader(config_dir=tmp_path, profile="dev", schema=RootSchema).load()
+
+    assert "Type mismatch at 'app.debug_mode'" in str(exc.value)
+
+
+def test_schema_validation_unknown_key_rejected(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+app:
+  name: TestApp
+  debug_mode: true
+database:
+  host: localhost
+  port: 5432
+  driver: postgresql
+""",
+    )
+
+    with pytest.raises(ConfigValidationError) as exc:
+        ConfigLoader(config_dir=tmp_path, profile="dev", schema=RootSchema).load()
+
+    assert "Unknown key 'database.driver'" in str(exc.value)
+
+
+def test_schema_validation_nested_type_path(tmp_path):
+    _write_yaml(
+        tmp_path / "application.yml",
+        """
+app:
+  name: TestApp
+  debug_mode: true
+database:
+  host: localhost
+  port: not-a-number
+""",
+    )
+
+    with pytest.raises(ConfigValidationError) as exc:
+        ConfigLoader(config_dir=tmp_path, profile="dev", schema=RootSchema).load()
+
+    assert "Type mismatch at 'database.port'" in str(exc.value)


### PR DESCRIPTION
## Summary
- add modular `sprigconfig.validation` with opt-in dataclass schema validation
- add `ConfigValidationError` and support `schema=` in `ConfigLoader` and `load_config`
- validate the fully merged config before runtime metadata and secret wrappers are injected
- preserve legacy loading behavior when `schema=` is omitted
- add user documentation for schema validation and correct stale public API examples
- separate public GitHub Pages content from maintainer and historical documentation

## Backward compatibility
- validation is never invoked unless the caller passes `schema=`
- a configuration value that conflicts with a code-side type still loads unchanged without `schema=`
- legacy `load_config(profile=..., config_dir=...)` usage remains supported
- YAML, JSON, TOML, recursive imports, profile overlays, defaults, optionals, typed collections, runtime metadata, CLI, secrets, injection, and instantiation remain covered

## Validation
- `poetry run pytest` — 179 passed
- `poetry run ruff check src tests/test_validation.py` — passed
- `poetry run mkdocs build --strict` — passed
- package wheel built successfully and includes `sprigconfig.validation`
- Python 3.11 and 3.13 source compilation passed

Closes #6
