### PR TITLE
fix: update vulnerable documentation dependencies

### DIFF
--- a/sprig-config-module/poetry.lock
+++ b/sprig-config-module/poetry.lock
@@ -938,14 +938,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.57"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["docs"]
 files = [
-    {file = "gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9"},
-    {file = "gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc"},
+    {file = "gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf"},
+    {file = "gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488"},
 ]
 
 [package.dependencies]
@@ -953,7 +953,7 @@ gitdb = ">=4.0.1,<5"
 
 [package.extras]
 doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
-test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+test = ["basedpyright (==1.39.9) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "griffe"
@@ -2087,14 +2087,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 description = "Extension pack for Python Markdown."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["docs"]
 files = [
-    {file = "pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6"},
-    {file = "pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354"},
+    {file = "pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2"},
+    {file = "pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0"},
 ]
 
 [package.dependencies]
@@ -2858,4 +2858,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "2bd4e31058c01f6221aa7969200560ae0ff36d76e5cb9a9cd02f8faabbc8aa09"
+content-hash = "d630b62c4dbf7b9cbbee83c19ad2d3a67f6f73cb921f639a309754fa4cbeab42"

--- a/sprig-config-module/pyproject.toml
+++ b/sprig-config-module/pyproject.toml
@@ -67,6 +67,8 @@ mkdocs-material = "^9.5.0"
 mkdocstrings = {extras = ["python"], version = "^0.26.0"}
 mkdocs-git-revision-date-localized-plugin = "^1.3.0"
 click = "^8.3.3"
+gitpython = ">=3.1.55"
+pymdown-extensions = ">=11.0.0"
 
 [tool.pytest.ini_options]
 addopts = "-v"


### PR DESCRIPTION
## Summary

Updates vulnerable documentation dependencies identified by the security audit.

## Vulnerabilities addressed

### GitPython

- GHSA-2f96-g7mh-g2hx
- GHSA-v396-v7q4-x2qj
- GHSA-956x-8gvw-wg5v
- GHSA-3rp5-jjmw-4wv2
- GHSA-fjr4-x663-mwxc
- GHSA-6p8h-3wgx-97gf
- GHSA-r9mr-m37c-5fr3
- GHSA-94p4-4cq8-9g67

### pymdown-extensions

- CVE-2026-61632

## Changes

- Updates GitPython from `3.1.50` to `3.1.57`
- Updates pymdown-extensions from `10.21.3` to `11.0.1`
- Adds explicit secure minimum versions to prevent future lockfile regressions
- Regenerates the Poetry lockfile

## Validation

- `poetry check --lock` passed
- All 179 tests passed
- `pip-audit` reports no known vulnerabilities