### PR TITLE
ci: fail security scan on all vulnerabilities

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -120,21 +120,21 @@ jobs:
         run: python -m pip install --upgrade "pip>=26.1,<27" "poetry==2.3.1"
 
       - name: Install security dependencies
-        run: poetry install --without docs --no-ansi
+        run: poetry install --all-groups --no-ansi
 
       - name: Generate pip-audit JSON report
         continue-on-error: true
-        run: poetry run pip-audit --ignore-vuln PYSEC-2026-89 --format json --output pip-audit-report.json
+        run: poetry run pip-audit --format json --output pip-audit-report.json
 
       - name: Generate pip-audit Markdown report
         continue-on-error: true
-        run: poetry run pip-audit --ignore-vuln PYSEC-2026-89 --format markdown --output pip-audit-report.md
+        run: poetry run pip-audit --format markdown --output pip-audit-report.md
 
       - name: Generate pip-audit console report
         continue-on-error: true
         run: |
           set -o pipefail
-          poetry run pip-audit --ignore-vuln PYSEC-2026-89 2>&1 | tee pip-audit-report.txt
+          poetry run pip-audit 2>&1 | tee pip-audit-report.txt
 
       - name: Summarize pip-audit results
         if: always()
@@ -148,7 +148,7 @@ jobs:
 
           if not report_path.exists():
               summary_path.write_text("## pip-audit\n\nNo JSON report was generated.\n", encoding="utf-8")
-              raise SystemExit(0)
+              raise SystemExit(1)
 
           data = json.loads(report_path.read_text(encoding="utf-8"))
           dependencies = data.get("dependencies", [])
@@ -159,10 +159,10 @@ jobs:
               "",
               f"- Dependencies scanned: {len(dependencies)}",
               f"- Vulnerabilities found: {vulnerability_count}",
-              "- Ignored vulnerability: `PYSEC-2026-89`",
           ]
 
           summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+          raise SystemExit(1 if vulnerability_count else 0)
           PY
 
       - name: Upload pip-audit artifacts


### PR DESCRIPTION
## Summary

Updates vulnerable documentation dependencies and strengthens the daily security workflow so findings in any dependency group fail the build.

## Vulnerabilities addressed

### GitPython

- GHSA-2f96-g7mh-g2hx
- GHSA-v396-v7q4-x2qj
- GHSA-956x-8gvw-wg5v
- GHSA-3rp5-jjmw-4wv2
- GHSA-fjr4-x663-mwxc
- GHSA-6p8h-3wgx-97gf
- GHSA-r9mr-m37c-5fr3
- GHSA-94p4-4cq8-9g67

### pymdown-extensions

- CVE-2026-61632

## Dependency changes

- Updates GitPython from `3.1.50` to `3.1.57`
- Updates pymdown-extensions from `10.21.3` to `11.0.1`
- Adds explicit secure minimum versions
- Regenerates the Poetry lockfile

These packages belong to the optional documentation toolchain and are not runtime dependencies. No package release is required.

## Security workflow changes

- Installs all Poetry dependency groups before auditing
- Covers runtime, development, test, and documentation dependencies
- Removes the existing vulnerability exception
- Fails the workflow when any vulnerability is found
- Fails when an audit report cannot be generated
- Continues uploading audit reports for investigation

## Validation

- `poetry check --lock` passed
- All 179 tests passed
- Workflow YAML validation passed
- Full-environment `pip-audit` reports no known vulnerabilities